### PR TITLE
fix: wrong padding on the timezone block / missing terms

### DIFF
--- a/resources/lang/en/actions.php
+++ b/resources/lang/en/actions.php
@@ -7,5 +7,5 @@ return [
     'export_personal_data' => 'Export Personal Data',
     'understand'           => 'I Understand',
     'update'               => 'Update',
-
+    'select_timezone'      => 'Select Timezone',
 ];

--- a/resources/lang/en/pages.php
+++ b/resources/lang/en/pages.php
@@ -17,7 +17,12 @@ return [
         'update_timezone_title'            => 'Timezone',
         'update_timezone_description'      => 'Select a Timezone below and update it by clicking the update button.',
         'timezone_updated'                 => 'Timezone was successfully updated',
-
+        'password_information_title'       => 'Password',
+        'password_information_description' => 'Ensure your account is using a long, random password to stay secure.',
+        'contact_information_title'        => 'Contact Information',
+        'contact_information_description'  => "Update your account's contact information and email address.",
+        'gdpr_title'                       => 'General Data Protection Regulation (GDPR)',
+        'gdpr_description'                 => 'This will will create a zip containing all personal data to respect your right to data portability. You will receive the zip file on the email address linked to your Deployer account.',
     ],
 
 ];

--- a/resources/views/profile/update-timezone-form.blade.php
+++ b/resources/views/profile/update-timezone-form.blade.php
@@ -1,5 +1,5 @@
 <div>
-    <div class="flex flex-col px-8 lg:p-8 xl:mx-8">
+    <div class="flex flex-col">
         <span class="text-2xl font-semibold text-theme-secondary-900">@lang('fortify::pages.user-settings.update_timezone_title')</span>
         <span>@lang('fortify::pages.user-settings.update_timezone_description')</span>
         <div>


### PR DESCRIPTION
## Summary

- Add missing terms on the fortify package
- Fix the padding in the settings timezone block

Ticket https://app.clickup.com/t/fcqt8y

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

## Before

![image](https://user-images.githubusercontent.com/17262776/98162560-74212d80-1ed9-11eb-850c-f57f539cd1f3.png)

## After

![image](https://user-images.githubusercontent.com/17262776/98162614-856a3a00-1ed9-11eb-81ad-88f75180f2e4.png)

