### PR TITLE
feat: show successful response when the user doesnt exist

### DIFF
--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -18,20 +18,20 @@ use ARKEcosystem\Fortify\Components\UpdatePasswordForm;
 use ARKEcosystem\Fortify\Components\UpdateProfileInformationForm;
 use ARKEcosystem\Fortify\Components\UpdateProfilePhotoForm;
 use ARKEcosystem\Fortify\Components\UpdateTimezoneForm;
+use ARKEcosystem\Fortify\Http\Responses\FailedPasswordResetLinkRequestResponse as FortifyFailedPasswordResetLinkRequestResponse;
+use ARKEcosystem\Fortify\Http\Responses\SuccessfulPasswordResetLinkRequestResponse as FortifySuccessfulPasswordResetLinkRequestResponse;
 use ARKEcosystem\Fortify\Responses\FailedTwoFactorLoginResponse;
 use ARKEcosystem\Fortify\Responses\RegisterResponse;
 use ARKEcosystem\Fortify\Responses\TwoFactorLoginResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Fortify\Contracts\FailedPasswordResetLinkRequestResponse;
 use Laravel\Fortify\Contracts\FailedTwoFactorLoginResponse as FailedTwoFactorLoginResponseContract;
 use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
+use Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse;
 use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
 use Laravel\Fortify\Fortify;
 use Livewire\Livewire;
-use ARKEcosystem\Fortify\Http\Responses\FailedPasswordResetLinkRequestResponse as FortifyFailedPasswordResetLinkRequestResponse;
-use ARKEcosystem\Fortify\Http\Responses\SuccessfulPasswordResetLinkRequestResponse as FortifySuccessfulPasswordResetLinkRequestResponse;
-use Laravel\Fortify\Contracts\FailedPasswordResetLinkRequestResponse;
-use Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse;
 
 class FortifyServiceProvider extends ServiceProvider
 {

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -28,6 +28,10 @@ use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
 use Laravel\Fortify\Fortify;
 use Livewire\Livewire;
+use ARKEcosystem\Fortify\Http\Responses\FailedPasswordResetLinkRequestResponse as FortifyFailedPasswordResetLinkRequestResponse;
+use ARKEcosystem\Fortify\Http\Responses\SuccessfulPasswordResetLinkRequestResponse as FortifySuccessfulPasswordResetLinkRequestResponse;
+use Laravel\Fortify\Contracts\FailedPasswordResetLinkRequestResponse;
+use Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse;
 
 class FortifyServiceProvider extends ServiceProvider
 {
@@ -215,6 +219,16 @@ class FortifyServiceProvider extends ServiceProvider
         $this->app->singleton(
             TwoFactorLoginResponseContract::class,
             TwoFactorLoginResponse::class
+        );
+
+        $this->app->singleton(
+            FailedPasswordResetLinkRequestResponse::class,
+            FortifyFailedPasswordResetLinkRequestResponse::class
+        );
+
+        $this->app->singleton(
+            SuccessfulPasswordResetLinkRequestResponse::class,
+            FortifySuccessfulPasswordResetLinkRequestResponse::class
         );
     }
 }

--- a/src/Http/Responses/FailedPasswordResetLinkRequestResponse.php
+++ b/src/Http/Responses/FailedPasswordResetLinkRequestResponse.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ARKEcosystem\Fortify\Http\Responses;
+
+use Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse;
+use Laravel\Fortify\Http\Responses\FailedPasswordResetLinkRequestResponse as LaravelFailedPasswordResetLinkRequestResponse;
+use Illuminate\Support\Facades\Password;
+
+class FailedPasswordResetLinkRequestResponse extends LaravelFailedPasswordResetLinkRequestResponse
+{
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function toResponse($request)
+    {
+        // If the status is related to a user that doesn't exist, we show a successful
+        // status to prevent people from determining the registered users based on
+        // the error message.
+        if (in_array($this->status, [Password::RESET_LINK_SENT, Password::INVALID_USER])) {
+            return app(SuccessfulPasswordResetLinkRequestResponse::class, ['status' => $this->status])->toResponse($request);
+        }
+
+        return parent::toResponse($request);
+    }
+}

--- a/src/Http/Responses/FailedPasswordResetLinkRequestResponse.php
+++ b/src/Http/Responses/FailedPasswordResetLinkRequestResponse.php
@@ -4,16 +4,17 @@ declare(strict_types=1);
 
 namespace ARKEcosystem\Fortify\Http\Responses;
 
+use Illuminate\Support\Facades\Password;
 use Laravel\Fortify\Contracts\SuccessfulPasswordResetLinkRequestResponse;
 use Laravel\Fortify\Http\Responses\FailedPasswordResetLinkRequestResponse as LaravelFailedPasswordResetLinkRequestResponse;
-use Illuminate\Support\Facades\Password;
 
 class FailedPasswordResetLinkRequestResponse extends LaravelFailedPasswordResetLinkRequestResponse
 {
     /**
      * Create an HTTP response that represents the object.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param \Illuminate\Http\Request $request
+     *
      * @return \Symfony\Component\HttpFoundation\Response
      */
     public function toResponse($request)
@@ -21,7 +22,7 @@ class FailedPasswordResetLinkRequestResponse extends LaravelFailedPasswordResetL
         // If the status is related to a user that doesn't exist, we show a successful
         // status to prevent people from determining the registered users based on
         // the error message.
-        if (in_array($this->status, [Password::RESET_LINK_SENT, Password::INVALID_USER])) {
+        if (in_array($this->status, [Password::RESET_LINK_SENT, Password::INVALID_USER], true)) {
             return app(SuccessfulPasswordResetLinkRequestResponse::class, ['status' => $this->status])->toResponse($request);
         }
 

--- a/src/Http/Responses/SuccessfulPasswordResetLinkRequestResponse.php
+++ b/src/Http/Responses/SuccessfulPasswordResetLinkRequestResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ARKEcosystem\Fortify\Http\Responses;
+
+use Laravel\Fortify\Http\Responses\SuccessfulPasswordResetLinkRequestResponse as LaravelSuccessfulPasswordResetLinkRequestResponse;
+
+class SuccessfulPasswordResetLinkRequestResponse extends LaravelSuccessfulPasswordResetLinkRequestResponse
+{
+    /**
+     * Create an HTTP response that represents the object.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function toResponse($request)
+    {
+        flash()->success(__('pages.user-settings.reset_link_email'));
+
+        return $request->wantsJson()
+                    ? new JsonResponse(['message' => trans($this->status)], 200)
+                    : back()->with('status', trans($this->status));
+    }
+}

--- a/src/Http/Responses/SuccessfulPasswordResetLinkRequestResponse.php
+++ b/src/Http/Responses/SuccessfulPasswordResetLinkRequestResponse.php
@@ -11,7 +11,8 @@ class SuccessfulPasswordResetLinkRequestResponse extends LaravelSuccessfulPasswo
     /**
      * Create an HTTP response that represents the object.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param \Illuminate\Http\Request $request
+     *
      * @return \Symfony\Component\HttpFoundation\Response
      */
     public function toResponse($request)

--- a/src/Http/Responses/SuccessfulPasswordResetLinkRequestResponse.php
+++ b/src/Http/Responses/SuccessfulPasswordResetLinkRequestResponse.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace ARKEcosystem\Fortify\Http\Responses;
 
+use Illuminate\Http\JsonResponse;
 use Laravel\Fortify\Http\Responses\SuccessfulPasswordResetLinkRequestResponse as LaravelSuccessfulPasswordResetLinkRequestResponse;
 
 class SuccessfulPasswordResetLinkRequestResponse extends LaravelSuccessfulPasswordResetLinkRequestResponse

--- a/tests/Http/Responses/FailedPasswordResetLinkRequestResponseTest.php
+++ b/tests/Http/Responses/FailedPasswordResetLinkRequestResponseTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Password;
+use ARKEcosystem\Fortify\Http\Responses\FailedPasswordResetLinkRequestResponse;
+use Illuminate\Http\Request;
+
+it('if the status is for an invalid user it should return a successful response', function () {
+    $response = new FailedPasswordResetLinkRequestResponse(Password::INVALID_USER);
+    $response = $response->toResponse(new Request());
+
+    expect($response->getStatusCode())->toBe(302);
+    
+    expect(app('session.store')->get('errors'))->toBe(null);
+    
+    expect(app('session.store')->get('laravel_flash_message'))->toHaveKey('message');
+});
+
+
+it('if the status is for another kind of error return the error response', function () {
+    $response = new FailedPasswordResetLinkRequestResponse(Password::INVALID_TOKEN);
+    $response = $response->toResponse(new Request());
+
+    expect($response->getStatusCode())->toBe(302);
+    expect(app('session.store')->get('errors')->has('email'))->toBe(true);
+});

--- a/tests/Http/Responses/FailedPasswordResetLinkRequestResponseTest.php
+++ b/tests/Http/Responses/FailedPasswordResetLinkRequestResponseTest.php
@@ -2,21 +2,20 @@
 
 declare(strict_types=1);
 
-use Illuminate\Support\Facades\Password;
 use ARKEcosystem\Fortify\Http\Responses\FailedPasswordResetLinkRequestResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Password;
 
 it('if the status is for an invalid user it should return a successful response', function () {
     $response = new FailedPasswordResetLinkRequestResponse(Password::INVALID_USER);
     $response = $response->toResponse(new Request());
 
     expect($response->getStatusCode())->toBe(302);
-    
+
     expect(app('session.store')->get('errors'))->toBe(null);
-    
+
     expect(app('session.store')->get('laravel_flash_message'))->toHaveKey('message');
 });
-
 
 it('if the status is for another kind of error return the error response', function () {
     $response = new FailedPasswordResetLinkRequestResponse(Password::INVALID_TOKEN);

--- a/tests/Http/Responses/SuccessfulPasswordResetLinkRequestResponseTest.php
+++ b/tests/Http/Responses/SuccessfulPasswordResetLinkRequestResponseTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Password;
+use ARKEcosystem\Fortify\Http\Responses\SuccessfulPasswordResetLinkRequestResponse;
+
+it('The success response flash a message', function () {
+    $response = new SuccessfulPasswordResetLinkRequestResponse(Password::RESET_LINK_SENT);
+    $response = $response->toResponse(new Request());
+
+    expect($response->getStatusCode())->toBe(302);
+    
+    expect(app('session.store')->get('laravel_flash_message'))->toHaveKey('message');
+});

--- a/tests/Http/Responses/SuccessfulPasswordResetLinkRequestResponseTest.php
+++ b/tests/Http/Responses/SuccessfulPasswordResetLinkRequestResponseTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
+use ARKEcosystem\Fortify\Http\Responses\SuccessfulPasswordResetLinkRequestResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Password;
-use ARKEcosystem\Fortify\Http\Responses\SuccessfulPasswordResetLinkRequestResponse;
 
 it('The success response flash a message', function () {
     $response = new SuccessfulPasswordResetLinkRequestResponse(Password::RESET_LINK_SENT);
     $response = $response->toResponse(new Request());
 
     expect($response->getStatusCode())->toBe(302);
-    
+
     expect(app('session.store')->get('laravel_flash_message'))->toHaveKey('message');
 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

If the reset password form returns an error related to a user that doesn't exist, we show a successful status to prevent people from determining the registered users based on the error message.

The message is a flash message
![image](https://user-images.githubusercontent.com/17262776/101195325-28d47900-3657-11eb-9f41-d3601290a8f3.png)


## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
