### PR TITLE
feat: add password validation component on the reset password form

### DIFF
--- a/resources/views/auth/reset-password-form.blade.php
+++ b/resources/views/auth/reset-password-form.blade.php
@@ -1,0 +1,65 @@
+<form
+    method="POST"
+    action="{{ route('password.update') }}"
+    class="flex flex-col p-8 mx-4 border rounded-lg border-theme-secondary-200 md:mx-0 lg:p-8 xl:mx-8"
+    x-data="{ isTyping: false }"
+>
+    @csrf
+
+    <input type="hidden" name="token" value="{{ $token }}">
+
+    <div class="mb-8">
+        <div class="flex flex-1">
+            <x-ark-input
+                wire:model.defer="state.email"
+                no-model
+                type="email"
+                name="email"
+                :label="trans('fortify::forms.email')"
+                autocomplete="email"
+                class="w-full"
+                :autofocus="true"
+                :required="true"
+                :errors="$errors"
+                readonly
+            />
+        </div>
+    </div>
+
+    <x:ark-fortify::password-rules class="mb-8" :password-rules="$passwordRules">
+        <x-ark-input
+            model="state.password"
+            type="password"
+            name="password"
+            :label="trans('fortify::forms.password')"
+            autocomplete="new-password"
+            class="w-full mb-2"
+            required="true"
+            @keydown="isTyping=true"
+            :errors="$errors"
+        />
+    </x:ark-fortify::password-rules>
+
+    <div class="mb-8">
+        <div class="flex flex-1">
+            <x-ark-input
+                model="state.password_confirmation"
+                type="password"
+                name="password_confirmation"
+                :label="trans('fortify::forms.confirm_password')"
+                autocomplete="new-password"
+                class="w-full"
+                :required="true"
+                :errors="$errors"
+            />
+        </div>
+    </div>
+
+    <div class="flex flex-col items-center justify-between w-full space-y-2 md:flex-row md:space-y-0">
+        <a href="{{ route('login') }}" class="link">@lang('fortify::actions.cancel')</a>
+
+        <button type="submit" class="w-full button-primary md:w-auto">
+            @lang('fortify::actions.reset_password')
+        </button>
+    </div>
+</form>

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -14,78 +14,10 @@
 @section('content')
     <div class="container mx-auto">
         <div class="mx-auto my-8 md:w-3/4 lg:w-3/5 xl:w-1/2">
-            <h1 class="mx-4 text-2xl font-bold md:text-4xl md:mx-8 xl:mx-16 text-center">
-                @lang('fortify::auth.reset-password.page_header')
-            </h1>
+            <h1 class="mx-4 text-2xl font-bold md:text-4xl md:mx-8 xl:mx-16">@lang('fortify::auth.reset-password.page_header')</h1>
 
             <div class="mt-5 lg:mt-8">
-                <form
-                    method="POST"
-                    action="{{ route('password.update') }}"
-                    class="flex flex-col p-8 mx-4 border rounded-lg border-theme-secondary-200 md:mx-0 lg:p-8 xl:mx-8"
-                >
-                    @csrf
-
-                    <input type="hidden" name="token" value="{{ $request->route('token') }}">
-
-                    <div class="mb-8">
-                        <div class="flex flex-1">
-                            <x-ark-input
-                                type="email"
-                                name="email"
-                                :label="trans('fortify::forms.email')"
-                                autocomplete="email"
-                                class="w-full"
-                                :autofocus="true"
-                                :value="old('email', $request->email)"
-                                :required="true"
-                                :errors="$errors"
-                                readonly
-                            />
-                        </div>
-                    </div>
-
-                    <div class="mb-8">
-                        <div class="flex flex-1">
-                            <x-ark-input
-                                type="password"
-                                name="password"
-                                :label="trans('fortify::forms.password')"
-                                autocomplete="new-password"
-                                class="w-full"
-                                :required="true"
-                                :errors="$errors"
-                            />
-                        </div>
-                        @if (! request()->session()->get('errors'))
-                            <div class="text-sm text-theme-secondary-600">@lang('fortify::forms.update-password.requirements_notice')</div>
-                        @endif
-                    </div>
-
-                    <div class="mb-8">
-                        <div class="flex flex-1">
-                            <x-ark-input
-                                type="password"
-                                name="password_confirmation"
-                                :label="trans('fortify::forms.confirm_password')"
-                                autocomplete="new-password"
-                                class="w-full"
-                                :required="true"
-                                :errors="$errors"
-                            />
-                        </div>
-                    </div>
-
-                    <div class="flex flex-col-reverse space-y-4 sm:space-y-0 sm:flex-row items-center justify-between">
-                        <div class="flex-1 mt-8 sm:mt-0">
-                            <a href="{{ route('login') }}" class="link">@lang('fortify::actions.cancel')</a>
-                        </div>
-
-                        <button type="submit" class="w-full button-secondary md:w-auto">
-                            @lang('fortify::actions.reset_password')
-                        </button>
-                    </div>
-                </form>
+                <livewire:auth.reset-password-form />
             </div>
         </div>
     </div>

--- a/src/Components/ResetPasswordForm.php
+++ b/src/Components/ResetPasswordForm.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ARKEcosystem\Fortify\Components;
+
+use ARKEcosystem\Fortify\Components\Concerns\ValidatesPassword;
+use Livewire\Component;
+
+class ResetPasswordForm extends Component
+{
+    use ValidatesPassword;
+
+    public $token; 
+
+    public array $state = [
+        'email'                 => '',
+        'password'              => '',
+        'password_confirmation' => '',
+    ];
+
+    public function mount()
+    {
+        $this->token = request()->route('token');
+        $this->state['email'] = old('email', request()->email);
+    }
+
+    /**
+     * Render the component.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function render()
+    {
+        return view('ark-fortify::auth.reset-password-form');
+    }
+}

--- a/src/Components/ResetPasswordForm.php
+++ b/src/Components/ResetPasswordForm.php
@@ -11,7 +11,7 @@ class ResetPasswordForm extends Component
 {
     use ValidatesPassword;
 
-    public $token; 
+    public $token;
 
     public array $state = [
         'email'                 => '',
@@ -21,7 +21,7 @@ class ResetPasswordForm extends Component
 
     public function mount()
     {
-        $this->token = request()->route('token');
+        $this->token          = request()->route('token');
         $this->state['email'] = old('email', request()->email);
     }
 

--- a/src/FortifyServiceProvider.php
+++ b/src/FortifyServiceProvider.php
@@ -13,6 +13,7 @@ use ARKEcosystem\Fortify\Components\DeleteUserForm;
 use ARKEcosystem\Fortify\Components\ExportUserData;
 use ARKEcosystem\Fortify\Components\LogoutOtherBrowserSessionsForm;
 use ARKEcosystem\Fortify\Components\RegisterForm;
+use ARKEcosystem\Fortify\Components\ResetPasswordForm;
 use ARKEcosystem\Fortify\Components\TwoFactorAuthenticationForm;
 use ARKEcosystem\Fortify\Components\UpdatePasswordForm;
 use ARKEcosystem\Fortify\Components\UpdateProfileInformationForm;
@@ -109,6 +110,7 @@ class FortifyServiceProvider extends ServiceProvider
         Livewire::component('profile.update-profile-photo-form', UpdateProfilePhotoForm::class);
         Livewire::component('profile.update-timezone-form', UpdateTimezoneForm::class);
         Livewire::component('auth.register-form', RegisterForm::class);
+        Livewire::component('auth.reset-password-form', ResetPasswordForm::class);
     }
 
     /**


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed, and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/aytm5y

The reset password form now live validates the password.

![image](https://user-images.githubusercontent.com/17262776/101207694-e320ac00-3668-11eb-947b-3f31d77816f2.png)

Note: On marketsquare there is a bug where the password input lost its focus after the first request, that errors are in every place the password validation component is used (register, update password, etc.). Apparently, that error is only on marketsquare. The rest of the projects are working fine. I'll take care of that issue in a separate PR

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
