### PR TITLE
refactor: require `DeleteUser` to be bound to container

### DIFF
--- a/resources/views/profile/delete-user-form.blade.php
+++ b/resources/views/profile/delete-user-form.blade.php
@@ -33,9 +33,11 @@
 
             <x-slot name="buttons">
                 <div class="flex flex-col w-full sm:flex-row justify-end mt-5 space-y-4 sm:space-y-0 sm:space-x-3">
-                    <button class="button-secondary"
-                        wire:click="$toggle('confirmingUserDeletion')">@lang('fortify::actions.cancel')</button>
-                    <button class="inline-flex justify-center items-center button-primary" wire:click="destroy">
+                    <button class="button-secondary" wire:click="$toggle('confirmingUserDeletion')">
+                        @lang('fortify::actions.cancel')
+                    </button>
+
+                    <button class="inline-flex justify-center items-center button-primary" wire:click="deleteUser">
                         @svg('trash', 'h-4 w-4')
                         <span class="ml-2">@lang('fortify::actions.delete')</span>
                     </button>
@@ -44,4 +46,3 @@
         </x-ark-modal>
     @endif
 </div>
-

--- a/src/Components/DeleteUserForm.php
+++ b/src/Components/DeleteUserForm.php
@@ -33,14 +33,14 @@ class DeleteUserForm extends Component
     /**
      * Delete the current user.
      *
-     * @param \ARKEcosystem\Fortify\Contracts $deleter
+     * @param \ARKEcosystem\Fortify\Contracts\DeleteUser $deleter
      * @param \Illuminate\Contracts\Auth\StatefulGuard $auth
      *
      * @return void
      */
     public function deleteUser(DeleteUser $deleter, StatefulGuard $auth)
     {
-        resolve(DeleteUser::class)->delete(Auth::user()->fresh());
+        $deleter->delete(Auth::user()->fresh());
 
         $auth->logout();
 

--- a/src/Components/DeleteUserForm.php
+++ b/src/Components/DeleteUserForm.php
@@ -34,7 +34,7 @@ class DeleteUserForm extends Component
      * Delete the current user.
      *
      * @param \ARKEcosystem\Fortify\Contracts\DeleteUser $deleter
-     * @param \Illuminate\Contracts\Auth\StatefulGuard $auth
+     * @param \Illuminate\Contracts\Auth\StatefulGuard   $auth
      *
      * @return void
      */

--- a/src/Components/DeleteUserForm.php
+++ b/src/Components/DeleteUserForm.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace ARKEcosystem\Fortify\Components;
 
-use ARKEcosystem\Fortify\Actions\DeleteUser;
-use Illuminate\Contracts\Auth\StatefulGuard;
+use Livewire\Component;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Contracts\Auth\StatefulGuard;
+use ARKEcosystem\Fortify\Contracts\DeleteUser;
 use Illuminate\Validation\ValidationException;
-use Livewire\Component;
 
 class DeleteUserForm extends Component
 {
@@ -35,14 +35,14 @@ class DeleteUserForm extends Component
     /**
      * Delete the current user.
      *
-     * @param \ARKEcosystem\Fortify\Actions\DeleteUser $deleter
+     * @param \ARKEcosystem\Fortify\Contracts $deleter
      * @param \Illuminate\Contracts\Auth\StatefulGuard $auth
      *
      * @return void
      */
     public function deleteUser(DeleteUser $deleter, StatefulGuard $auth)
     {
-        $deleter->delete(Auth::user()->fresh());
+        resolve(DeleteUser::class)->delete(Auth::user()->fresh());
 
         $auth->logout();
 

--- a/src/Components/DeleteUserForm.php
+++ b/src/Components/DeleteUserForm.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace ARKEcosystem\Fortify\Components;
 
-use Livewire\Component;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Contracts\Auth\StatefulGuard;
 use ARKEcosystem\Fortify\Contracts\DeleteUser;
+use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Component;
 
 class DeleteUserForm extends Component
 {
@@ -33,7 +33,7 @@ class DeleteUserForm extends Component
     /**
      * Delete the current user.
      *
-     * @param \ARKEcosystem\Fortify\Contracts $deleter
+     * @param \ARKEcosystem\Fortify\Contracts          $deleter
      * @param \Illuminate\Contracts\Auth\StatefulGuard $auth
      *
      * @return void

--- a/src/Components/DeleteUserForm.php
+++ b/src/Components/DeleteUserForm.php
@@ -42,8 +42,6 @@ class DeleteUserForm extends Component
      */
     public function deleteUser(DeleteUser $deleter, StatefulGuard $auth)
     {
-        $this->resetErrorBag();
-
         $deleter->delete(Auth::user()->fresh());
 
         $auth->logout();

--- a/src/Components/DeleteUserForm.php
+++ b/src/Components/DeleteUserForm.php
@@ -21,21 +21,12 @@ class DeleteUserForm extends Component
     public $confirmingUserDeletion = false;
 
     /**
-     * The user's current password.
-     *
-     * @var string
-     */
-    public $password = '';
-
-    /**
      * Confirm that the user would like to delete their account.
      *
      * @return void
      */
     public function confirmUserDeletion()
     {
-        $this->password = '';
-
         $this->dispatchBrowserEvent('confirming-delete-user');
 
         $this->confirmingUserDeletion = true;
@@ -52,12 +43,6 @@ class DeleteUserForm extends Component
     public function deleteUser(DeleteUser $deleter, StatefulGuard $auth)
     {
         $this->resetErrorBag();
-
-        if (! Hash::check($this->password, Auth::user()->password)) {
-            throw ValidationException::withMessages([
-                'password' => [trans('fortify::validation.password_doesnt_match_records')],
-            ]);
-        }
 
         $deleter->delete(Auth::user()->fresh());
 

--- a/src/Contracts/DeleteUser.php
+++ b/src/Contracts/DeleteUser.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace ARKEcosystem\Fortify\Actions;
+namespace ARKEcosystem\Fortify\Contracts;
 
-class DeleteUser
+interface DeleteUser
 {
     /**
      * Delete the given user.
@@ -13,8 +13,5 @@ class DeleteUser
      *
      * @return void
      */
-    public function delete($user)
-    {
-        $user->delete();
-    }
+    public function delete($user);
 }


### PR DESCRIPTION
Each project should provide its own implementation because there are no common deletions besides the user itself. All relationships are custom.