### PR TITLE
feat: add grid to password rules

### DIFF
--- a/resources/views/components/password-rules.blade.php
+++ b/resources/views/components/password-rules.blade.php
@@ -1,19 +1,19 @@
-@props(['passwordRules', 'isTyping'])
+@props(['passwordRules', 'isTyping', 'rulesWrapperClass' => 'grid gap-4 mt-4 sm:grid-cols-2'])
 <div {{ $attributes }}>
     <div class="flex flex-1">
         {{ $slot }}
     </div>
 
     <div class="flex flex-col text-sm">
-        <span x-show="!isTyping">@lang('fortify::forms.update-password.requirements_notice')</span>
-        <div x-show="isTyping" x-cloak>
+        <span x-show="!isTyping ">@lang('fortify::forms.update-password.requirements_notice')</span>
+        <div class="{{ $rulesWrapperClass }}" x-show="isTyping" x-cloak>
             @foreach($passwordRules as $ruleName => $ruleIsValid)
-                <div class="flex items-center w-full mt-4 space-x-2">
+                <div class="flex items-center space-x-2 min-w-1/3">
                     @if ($ruleIsValid)
                         <div class="flex items-center justify-center flex-shrink-0 w-5 h-5 rounded-full bg-theme-success-200">
                             @svg('checkmark', 'text-theme-success-500 h-2 w-2')
                     @elseif(! $ruleIsValid)
-                        <div class="flex items-center justify-center flex-shrink-0 w-5 h-5 rounded-full border-2 border-theme-secondary-700">
+                        <div class="flex items-center justify-center flex-shrink-0 w-5 h-5 border-2 rounded-full border-theme-secondary-700">
                     @else
                         <div class="flex items-center justify-center flex-shrink-0 w-5 h-5 rounded-full bg-theme-danger-200">
                             @svg('exclamation', 'text-theme-danger-500 h-5 w-5')

--- a/resources/views/profile/update-password-form.blade.php
+++ b/resources/views/profile/update-password-form.blade.php
@@ -13,14 +13,14 @@
         <div class="space-y-4">
             <x-ark-input type="password" name="current_password" model="state.current_password" :label="trans('fortify::forms.current_password')" :errors="$errors" />
 
-            <x:ark-fortify::password-rules class="w-full" :password-rules="$passwordRules" is-typing="isTyping">
+            <x:ark-fortify::password-rules class="w-full" :password-rules="$passwordRules" is-typing="isTyping" rules-wrapper-class="grid gap-4 my-4 sm:grid-cols-2 lg:grid-cols-3">
                 <x-ark-input type="password" name="password" model="state.password" class="w-full" :label="trans('fortify::forms.new_password')" @keydown="isTyping=true" :errors="$errors" />
             </x:ark-fortify::password-rules>
 
             <x-ark-input type="password" name="password_confirmation" model="state.password_confirmation" :label="trans('fortify::forms.confirm_password')" :errors="$errors" />
         </div>
-        <div class="flex sm:justify-end mt-8 w-full">
-            <button type="submit" class="button-secondary w-full sm:w-auto">@lang('fortify::actions.update')</button>
+        <div class="flex w-full mt-8 sm:justify-end">
+            <button type="submit" class="w-full button-secondary sm:w-auto">@lang('fortify::actions.update')</button>
         </div>
     </form>
 </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/bjwhm6
Responsive grid for the password rules:


1. Now it has 2 columns by default on > small screens (safer breakpoint that looks good on the registration form that has a wrapper)

![image](https://user-images.githubusercontent.com/17262776/102533901-e884ea00-409d-11eb-8303-60a3796f1c95.png)

2. For the update-password form it overrides the breakpoints to use 3 columns on the bigger screens
![image](https://user-images.githubusercontent.com/17262776/102534195-46b1cd00-409e-11eb-9ca4-ca82d25adf48.png)
![image](https://user-images.githubusercontent.com/17262776/102534208-4d404480-409e-11eb-9079-4c02fe9f5461.png)
![image](https://user-images.githubusercontent.com/17262776/102534226-54675280-409e-11eb-8935-c440ed2d7b15.png)



## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
