### PR TITLE
feat: add readonly option for upload photo form

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "arkecosystem/ui",
-            "version": "1.3.32",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ArkEcosystem/laravel-ui.git",
-                "reference": "6c08396f38e069d65a4c53caa117d89bcda3cc28"
+                "reference": "29e25d44205bd23f10275f21424fda3c28577cae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ArkEcosystem/laravel-ui/zipball/6c08396f38e069d65a4c53caa117d89bcda3cc28",
-                "reference": "6c08396f38e069d65a4c53caa117d89bcda3cc28",
+                "url": "https://api.github.com/repos/ArkEcosystem/laravel-ui/zipball/29e25d44205bd23f10275f21424fda3c28577cae",
+                "reference": "29e25d44205bd23f10275f21424fda3c28577cae",
                 "shasum": ""
             },
             "require": {
@@ -77,9 +77,9 @@
             "description": "User-Interface Scaffolding for Laravel. Powered by TailwindCSS.",
             "support": {
                 "issues": "https://github.com/ArkEcosystem/laravel-ui/issues",
-                "source": "https://github.com/ArkEcosystem/laravel-ui/tree/1.3.32"
+                "source": "https://github.com/ArkEcosystem/laravel-ui/tree/1.5.1"
             },
-            "time": "2021-01-15T15:30:36+00:00"
+            "time": "2021-01-20T15:43:20+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",

--- a/resources/views/profile/update-profile-photo-form.blade.php
+++ b/resources/views/profile/update-profile-photo-form.blade.php
@@ -7,6 +7,7 @@
 >
     <form wire:submit.prevent="store" id="livewire-form">
         <x-ark-upload-image
+            :readonly="$readonly"
             :image="$this->user->photo"
             :upload-text="__('fortify::forms.upload-avatar.upload_avatar')"
             :delete-tooltip="__('fortify::forms.upload-avatar.delete_avatar')"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

The upload photo form now has the new `readonly` prop that was added here https://github.com/ArkEcosystem/laravel-ui/pull/200 so the profile photo form can be used as read only

note: The laravel-ui PR need to be merged/published and the I need to update the dependency here


## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
