### PR TITLE
refactor: swap name & username inputs within register-form and use Display Name instead of Name

### DIFF
--- a/resources/lang/en/forms.php
+++ b/resources/lang/en/forms.php
@@ -11,6 +11,7 @@ return [
     'new_password'     => 'New Password',
     'password'         => 'Password',
     'username'         => 'Username',
+    'display_name'     => 'Display Name',
     'code'             => 'Code',
     'recovery_code'    => 'Recovery Code',
 

--- a/resources/views/auth/register-form.blade.php
+++ b/resources/views/auth/register-form.blade.php
@@ -15,7 +15,7 @@
                     wire:model.defer="state.name"
                     no-model
                     name="name"
-                    :label="trans('fortify::forms.name')"
+                    :label="trans('fortify::forms.username')"
                     autocomplete="name"
                     class="w-full"
                     :autofocus="true"
@@ -33,7 +33,7 @@
                     no-model
                     type="text"
                     name="username"
-                    :label="trans('fortify::forms.username')"
+                    :label="trans('fortify::forms.display_name')"
                     autocomplete="username"
                     class="w-full"
                     :errors="$errors"

--- a/resources/views/auth/register-form.blade.php
+++ b/resources/views/auth/register-form.blade.php
@@ -6,6 +6,23 @@
 >
     @csrf
 
+    @if(Config::get('fortify.username_alt'))
+        <div class="mb-8">
+            <div class="flex flex-1">
+                <x-ark-input
+                    wire:model.defer="state.username"
+                    no-model
+                    type="text"
+                    name="username"
+                    :label="trans('fortify::forms.username')"
+                    autocomplete="username"
+                    class="w-full"
+                    :errors="$errors"
+                />
+            </div>
+        </div>
+    @endif
+
     @if($invitation)
         <input type="hidden" name="name" value="{{ $invitation->name }}" />
     @else
@@ -15,27 +32,10 @@
                     wire:model.defer="state.name"
                     no-model
                     name="name"
-                    :label="trans('fortify::forms.username')"
+                    :label="trans('fortify::forms.display_name')"
                     autocomplete="name"
                     class="w-full"
                     :autofocus="true"
-                    :errors="$errors"
-                />
-            </div>
-        </div>
-    @endif
-
-    @if(Config::get('fortify.username_alt'))
-        <div class="mb-8">
-            <div class="flex flex-1">
-                <x-ark-input
-                    wire:model.defer="state.username"
-                    no-model
-                    type="text"
-                    name="username"
-                    :label="trans('fortify::forms.display_name')"
-                    autocomplete="username"
-                    class="w-full"
                     :errors="$errors"
                 />
             </div>


### PR DESCRIPTION
## Summary

~~@ItsANameToo Just changed what's displayed right now, but I guess we want more than just that ? So e.g changing that whole section~~ ;

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged