### PR TITLE
feat: store the profile photos with responsive images

### DIFF
--- a/src/Components/UpdateProfilePhotoForm.php
+++ b/src/Components/UpdateProfilePhotoForm.php
@@ -37,7 +37,7 @@ class UpdateProfilePhotoForm extends Component
 
         $file = $this->imageSingle->storePubliclyAs('uploads', $this->imageSingle->hashName());
 
-        $this->user->addMediaFromDisk($file)->toMediaCollection('photo');
+        $this->user->addMediaFromDisk($file)->withResponsiveImages()->toMediaCollection('photo');
         $this->user->refresh();
     }
 

--- a/src/Models/Concerns/HasPhoto.php
+++ b/src/Models/Concerns/HasPhoto.php
@@ -18,7 +18,7 @@ trait HasPhoto
 
     public function getPhotoAttribute(): string
     {
-        return optional($this->getPhoto())->getUrl() ?: '';
+        return $this->getFirstMediaUrl('photo');
     }
 
     public function registerMediaCollections(): void

--- a/src/Models/Concerns/HasPhoto.php
+++ b/src/Models/Concerns/HasPhoto.php
@@ -5,14 +5,20 @@ declare(strict_types=1);
 namespace ARKEcosystem\Fortify\Models\Concerns;
 
 use Spatie\MediaLibrary\InteractsWithMedia;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 trait HasPhoto
 {
     use InteractsWithMedia;
 
+    public function getPhoto(): ?Media
+    {
+        return $this->getFirstMedia('photo');
+    }
+
     public function getPhotoAttribute(): string
     {
-        return $this->getFirstMediaUrl('photo');
+        return optional($this->getPhoto())->getUrl() ?: '';
     }
 
     public function registerMediaCollections(): void

--- a/tests/Components/UpdateProfilePhotoFormTest.php
+++ b/tests/Components/UpdateProfilePhotoFormTest.php
@@ -14,9 +14,7 @@ use Tests\MediaUser;
 it('can upload a photo', function () {
     $this
         ->mock(FileAdderFactory::class)
-        ->shouldReceive('createFromDisk->withResponsiveImages')
-        ->once()
-        ->shouldReceive('createFromDisk->toMediaCollection')
+        ->shouldReceive('createFromDisk->withResponsiveImages->toMediaCollection')
         ->once();
 
     $photo = UploadedFile::fake()->image('logo.jpeg');
@@ -47,9 +45,7 @@ it('cannot upload a photo that is too large', function () {
 it('can delete a photo', function () {
     $this
         ->mock(FileAdderFactory::class)
-        ->shouldReceive('createFromDisk->withResponsiveImages')
-        ->once()
-        ->shouldReceive('createFromDisk->toMediaCollection')
+        ->shouldReceive('createFromDisk->withResponsiveImages->toMediaCollection')
         ->once();
 
     $media = Mockery::mock(Media::class);

--- a/tests/Components/UpdateProfilePhotoFormTest.php
+++ b/tests/Components/UpdateProfilePhotoFormTest.php
@@ -14,7 +14,7 @@ use Tests\MediaUser;
 it('can upload a photo', function () {
     $this
         ->mock(FileAdderFactory::class)
-        ->shouldReceive('createFromDisk->toMediaCollection')
+        ->shouldReceive('createFromDisk->toMediaCollection->withResponsiveImages')
         ->once();
 
     $photo = UploadedFile::fake()->image('logo.jpeg');
@@ -45,7 +45,7 @@ it('cannot upload a photo that is too large', function () {
 it('can delete a photo', function () {
     $this
         ->mock(FileAdderFactory::class)
-        ->shouldReceive('createFromDisk->toMediaCollection')
+        ->shouldReceive('createFromDisk->toMediaCollection->withResponsiveImages')
         ->once();
 
     $media = Mockery::mock(Media::class);

--- a/tests/Components/UpdateProfilePhotoFormTest.php
+++ b/tests/Components/UpdateProfilePhotoFormTest.php
@@ -14,7 +14,9 @@ use Tests\MediaUser;
 it('can upload a photo', function () {
     $this
         ->mock(FileAdderFactory::class)
-        ->shouldReceive('createFromDisk->toMediaCollection->withResponsiveImages')
+        ->shouldReceive('createFromDisk->withResponsiveImages')
+        ->once()
+        ->shouldReceive('createFromDisk->toMediaCollection')
         ->once();
 
     $photo = UploadedFile::fake()->image('logo.jpeg');
@@ -45,7 +47,9 @@ it('cannot upload a photo that is too large', function () {
 it('can delete a photo', function () {
     $this
         ->mock(FileAdderFactory::class)
-        ->shouldReceive('createFromDisk->toMediaCollection->withResponsiveImages')
+        ->shouldReceive('createFromDisk->withResponsiveImages')
+        ->once()
+        ->shouldReceive('createFromDisk->toMediaCollection')
         ->once();
 
     $media = Mockery::mock(Media::class);

--- a/tests/Models/Concerns/HasPhotoTest.php
+++ b/tests/Models/Concerns/HasPhotoTest.php
@@ -17,6 +17,15 @@ class HasPhotoTest implements HasMedia
     use HasPhoto;
 }
 
+it('can access the photo', function () {
+    $subject = $this->getMockForTrait(HasPhoto::class, [], '', true, true, true, ['getFirstMedia']);
+    $subject->expects($this->any())
+        ->method('getFirstMedia')
+        ->will($this->returnValue(null));
+
+    expect($subject->getPhotoAttribute())->toBe('');
+});
+
 it('can access the photo url', function () {
     $subject = $this->getMockForTrait(HasPhoto::class, [], '', true, true, true, ['getFirstMediaUrl']);
     $subject->expects($this->any())

--- a/tests/Models/Concerns/HasPhotoTest.php
+++ b/tests/Models/Concerns/HasPhotoTest.php
@@ -8,6 +8,7 @@ use ARKEcosystem\Fortify\Models\Concerns\HasPhoto;
 use Mockery;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\MediaCollections\MediaCollection;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 /**
  * @coversNothing
@@ -18,12 +19,13 @@ class HasPhotoTest implements HasMedia
 }
 
 it('can access the photo', function () {
+    $media = new Media();
     $subject = $this->getMockForTrait(HasPhoto::class, [], '', true, true, true, ['getFirstMedia']);
     $subject->expects($this->any())
         ->method('getFirstMedia')
-        ->will($this->returnValue(null));
+        ->will($this->returnValue($media));
 
-    expect($subject->getPhotoAttribute())->toBe('');
+    expect($subject->getPhoto())->toBe($media);
 });
 
 it('can access the photo url', function () {

--- a/tests/Models/Concerns/HasPhotoTest.php
+++ b/tests/Models/Concerns/HasPhotoTest.php
@@ -17,7 +17,7 @@ class HasPhotoTest implements HasMedia
     use HasPhoto;
 }
 
-it('can access the photo', function () {
+it('can access the photo url', function () {
     $subject = $this->getMockForTrait(HasPhoto::class, [], '', true, true, true, ['getFirstMediaUrl']);
     $subject->expects($this->any())
         ->method('getFirstMediaUrl')


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Store the profile images with responsive images

Note: the image generation is queued by default in the spatie package (further explanation in the msq ticket) 

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
