### PR TITLE
fix: ignore 2fa field text when submitting recovery code

### DIFF
--- a/resources/views/auth/two-factor-challenge.blade.php
+++ b/resources/views/auth/two-factor-challenge.blade.php
@@ -28,32 +28,36 @@
         >
             @csrf
 
-            <div class="mb-8" x-show="! recovery">
-                <div class="flex flex-1">
-                    <x-ark-input
-                        type="text"
-                        name="code"
-                        :label="trans('fortify::forms.2fa_code')"
-                        class="w-full"
-                        :errors="$errors"
-                        autocomplete="one-time-code"
-                        input-mode="numeric"
-                        pattern="[0-9]*"
-                    />
+            <template x-if="! recovery">
+                <div class="mb-8">
+                    <div class="flex flex-1">
+                        <x-ark-input
+                            type="text"
+                            name="code"
+                            :label="trans('fortify::forms.2fa_code')"
+                            class="w-full"
+                            :errors="$errors"
+                            autocomplete="one-time-code"
+                            input-mode="numeric"
+                            pattern="[0-9]*"
+                        />
+                    </div>
                 </div>
-            </div>
+            </template>
 
-            <div class="mb-8" x-show="recovery" x-cloak>
-                <div class="flex flex-1">
-                    <x-ark-input
-                        type="password"
-                        name="recovery_code"
-                        :label="trans('fortify::forms.recovery_code')"
-                        class="w-full"
-                        :errors="$errors"
-                    />
+            <template x-if="recovery">
+                <div class="mb-8" x-cloak>
+                    <div class="flex flex-1">
+                        <x-ark-input
+                            type="password"
+                            name="recovery_code"
+                            :label="trans('fortify::forms.recovery_code')"
+                            class="w-full"
+                            :errors="$errors"
+                        />
+                    </div>
                 </div>
-            </div>
+            </template>
 
             <div class="flex flex-col-reverse items-center justify-between space-y-4 md:space-y-0 md:flex-row">
                 <button x-show="recovery === false" @click="recovery = true" type="button" class="w-full font-semibold link sm:w-auto">


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/fq5t25

This PRs removes (instead of hiding) the 2fa code input when the user changes to recovery to avoid conflicts when the form is submitted

Test by follow the same steps in the ticket, it should work now

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
