### PR TITLE
feat: separate two-factor and recovery code forms

### DIFF
--- a/resources/views/auth/two-factor-challenge.blade.php
+++ b/resources/views/auth/two-factor-challenge.blade.php
@@ -48,14 +48,10 @@
             </div>
 
             <div class="flex flex-col-reverse items-center justify-between sm:flex-row">
-                <button x-show="recovery === false" @click="recovery = true" type="button" class="w-full mt-4 font-semibold link sm:w-auto sm:mt-0">
+                <button @click="recovery = true" type="button" class="w-full mt-4 font-semibold link sm:w-auto sm:mt-0">
                     @lang('fortify::actions.enter_recovery_code')
                 </button>
                 
-                <button x-show="recovery === true" @click="recovery = false" type="button" class="w-full mt-4 font-semibold link sm:w-auto sm:mt-0" x-cloak>
-                    @lang('fortify::actions.enter_2fa_code')
-                </button>
-
                 <button type="submit" class="w-full button-secondary sm:w-auto">
                     @lang('fortify::actions.sign_in')
                 </button>
@@ -83,11 +79,7 @@
             </div>
 
             <div class="flex flex-col-reverse items-center justify-between sm:flex-row">
-                <button x-show="recovery === false" @click="recovery = true" type="button" class="w-full mt-4 font-semibold link sm:w-auto sm:mt-0">
-                    @lang('fortify::actions.enter_recovery_code')
-                </button>
-                
-                <button x-show="recovery === true" @click="recovery = false" type="button" class="w-full mt-4 font-semibold link sm:w-auto sm:mt-0" x-cloak>
+                <button @click="recovery = false" type="button" class="w-full mt-4 font-semibold link sm:w-auto sm:mt-0" x-cloak>
                     @lang('fortify::actions.enter_2fa_code')
                 </button>
 

--- a/resources/views/auth/two-factor-challenge.blade.php
+++ b/resources/views/auth/two-factor-challenge.blade.php
@@ -19,45 +19,33 @@
         </div>
     </div>
 
-    <div class="max-w-xl p-8 mx-auto">
+    <div
+        x-data="{ recovery: @json($errors->has('recovery_code')) }"
+        x-cloak
+        class="max-w-xl p-8 mx-auto"
+    >
         <form
-            x-data="{ recovery: @json($errors->has('recovery_code')) }"
+            x-show="!recovery"
             method="POST"
             action="{{ route('two-factor.login') }}"
             class="flex flex-col p-8 mx-4 border-2 rounded-lg border-theme-secondary-200"
         >
             @csrf
 
-            <template x-if="! recovery">
-                <div class="mb-8">
-                    <div class="flex flex-1">
-                        <x-ark-input
-                            type="text"
-                            name="code"
-                            :label="trans('fortify::forms.2fa_code')"
-                            class="w-full"
-                            :errors="$errors"
-                            autocomplete="one-time-code"
-                            input-mode="numeric"
-                            pattern="[0-9]*"
-                        />
-                    </div>
+            <div class="mb-8">
+                <div class="flex flex-1">
+                    <x-ark-input
+                        type="text"
+                        name="code"
+                        :label="trans('fortify::forms.2fa_code')"
+                        class="w-full"
+                        :errors="$errors"
+                        autocomplete="one-time-code"
+                        input-mode="numeric"
+                        pattern="[0-9]*"
+                    />
                 </div>
-            </template>
-
-            <template x-if="recovery">
-                <div class="mb-8" x-cloak>
-                    <div class="flex flex-1">
-                        <x-ark-input
-                            type="password"
-                            name="recovery_code"
-                            :label="trans('fortify::forms.recovery_code')"
-                            class="w-full"
-                            :errors="$errors"
-                        />
-                    </div>
-                </div>
-            </template>
+            </div>
 
             <div class="flex flex-col-reverse items-center justify-between sm:flex-row">
                 <button x-show="recovery === false" @click="recovery = true" type="button" class="w-full mt-4 font-semibold link sm:w-auto sm:mt-0">
@@ -74,6 +62,40 @@
             </div>
         </form>
 
+        <form
+            x-show="recovery"
+            method="POST"
+            action="{{ route('two-factor.login') }}"
+            class="flex flex-col p-8 mx-4 border-2 rounded-lg border-theme-secondary-200"
+        >
+            @csrf
+
+            <div class="mb-8" >
+                <div class="flex flex-1">
+                    <x-ark-input
+                        type="password"
+                        name="recovery_code"
+                        :label="trans('fortify::forms.recovery_code')"
+                        class="w-full"
+                        :errors="$errors"
+                    />
+                </div>
+            </div>
+
+            <div class="flex flex-col-reverse items-center justify-between sm:flex-row">
+                <button x-show="recovery === false" @click="recovery = true" type="button" class="w-full mt-4 font-semibold link sm:w-auto sm:mt-0">
+                    @lang('fortify::actions.enter_recovery_code')
+                </button>
+                
+                <button x-show="recovery === true" @click="recovery = false" type="button" class="w-full mt-4 font-semibold link sm:w-auto sm:mt-0" x-cloak>
+                    @lang('fortify::actions.enter_2fa_code')
+                </button>
+
+                <button type="submit" class="w-full button-secondary sm:w-auto">
+                    @lang('fortify::actions.sign_in')
+                </button>
+            </div>
+        </form>
     </div>
 
 @endsection


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/fv71zv

On the 2fa auth form the tooltip with the error message is not working because the inputs are not in the DOM when the tooltip is initialized, the problem is that the input is inside a `<template x-if>`  condition so when the tooltip plugin is initialized the inputs are not there yet.

That `<template>` condition was added to prevent conflicts within the 2fa and recovery forms so as an alternative and more reliable solution I separated both forms so I can get rid of the template tags and still prevent conflicts within forms.

To test: activate 2fa in your user account, logout and try to log in with a random 2fa code, you should see the tooltip with the error.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
