### PR TITLE
chore: add success message when the job for exporting the user data starts

### DIFF
--- a/resources/lang/en/pages.php
+++ b/resources/lang/en/pages.php
@@ -17,6 +17,7 @@ return [
         'update_timezone_title'             => 'Timezone',
         'update_timezone_description'       => 'Select a Timezone below and update it by clicking the update button.',
         'timezone_updated'                  => 'Timezone was successfully updated',
+        'data_exported'                     => 'We are processing your request. You should shortly receive an email with your data.',
         'password_information_title'        => 'Password',
         'password_information_description'  => 'Ensure your account is using a long, random password to stay secure.',
         'contact_information_title'         => 'Contact Information',

--- a/resources/views/profile/export-user-data.blade.php
+++ b/resources/views/profile/export-user-data.blade.php
@@ -3,8 +3,12 @@
         <span class="header-4">@lang('fortify::pages.user-settings.gdpr_title')</span>
         <span class="mt-4">@lang('fortify::pages.user-settings.gdpr_description')</span>
 
+        <div>
+            <x-ark-flash />
+        </div>
+
         <div class="flex justify-end mt-8">
-            <button type="submit" class="button-secondary w-full sm:w-auto" wire:click="export">@lang('fortify::actions.export_personal_data')</button>
+            <button type="submit" class="w-full button-secondary sm:w-auto" wire:click="export">@lang('fortify::actions.export_personal_data')</button>
         </div>
     </div>
 </div>

--- a/src/Components/ExportUserData.php
+++ b/src/Components/ExportUserData.php
@@ -20,6 +20,8 @@ class ExportUserData extends Component
     public function export(): void
     {
         dispatch(new CreatePersonalDataExportJob($this->user));
+
+        flash()->success(trans('fortify::pages.user-settings.data_exported'));
     }
 
     /**

--- a/tests/Components/ExportUserDataTest.php
+++ b/tests/Components/ExportUserDataTest.php
@@ -13,5 +13,6 @@ it('can export the user data', function () {
 
     Livewire::actingAs(createUserModel())
         ->test(ExportUserData::class)
-        ->call('export');
+        ->call('export')
+        ->assertSee(trans('fortify::pages.user-settings.data_exported'));
 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/qb1j7d

Adds a success message that explain to the user that he will receive an email shortly with his exported data.

(The success message may need a second opinion)

![image](https://user-images.githubusercontent.com/17262776/112047240-f175d380-8b44-11eb-9284-0d0515c1a266.png)


## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
