### PR TITLE
fix: handle null values on the password validator

### DIFF
--- a/src/Rules/Password.php
+++ b/src/Rules/Password.php
@@ -26,23 +26,26 @@ class Password extends Fortify
      */
     public function passes($attribute, $value)
     {
-        if ($this->needsLowercase($value ?: '')) {
+        // Handle potential NULL values
+        $value = $value ?: '';
+
+        if ($this->needsLowercase($value)) {
             return false;
         }
 
-        if ($this->needsUppercase($value ?: '')) {
+        if ($this->needsUppercase($value)) {
             return false;
         }
 
-        if ($this->needsNumeric($value ?: '')) {
+        if ($this->needsNumeric($value)) {
             return false;
         }
 
-        if ($this->needsSpecialCharacter($value ?: '')) {
+        if ($this->needsSpecialCharacter($value)) {
             return false;
         }
 
-        return ! $this->needsMinimumLength($value ?: '');
+        return ! $this->needsMinimumLength($value);
     }
 
     /**

--- a/src/Rules/Password.php
+++ b/src/Rules/Password.php
@@ -26,23 +26,23 @@ class Password extends Fortify
      */
     public function passes($attribute, $value)
     {
-        if ($this->needsLowercase($value)) {
+        if ($this->needsLowercase($value ?: '')) {
             return false;
         }
 
-        if ($this->needsUppercase($value)) {
+        if ($this->needsUppercase($value ?: '')) {
             return false;
         }
 
-        if ($this->needsNumeric($value)) {
+        if ($this->needsNumeric($value ?: '')) {
             return false;
         }
 
-        if ($this->needsSpecialCharacter($value)) {
+        if ($this->needsSpecialCharacter($value ?: '')) {
             return false;
         }
 
-        return ! $this->needsMinimumLength($value);
+        return ! $this->needsMinimumLength($value ?: '');
     }
 
     /**

--- a/tests/Rules/PasswordTest.php
+++ b/tests/Rules/PasswordTest.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 use ARKEcosystem\Fortify\Rules\Password;
 
+it('handle null values', function () {
+    $rule = (new Password())->requireUppercase()->requireNumeric()->requireSpecialCharacter();
+
+    expect($rule->passes('password', null))->toBeFalse();
+});
+
 it('can check for lowercase requirements', function () {
     $rule = (new Password())->requireLowercase();
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Solves an exception that happens when trying to validate a `null` value with the password validation rule

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
