### PR TITLE
feat: disable gdpr export button while busy

### DIFF
--- a/resources/views/profile/export-user-data.blade.php
+++ b/resources/views/profile/export-user-data.blade.php
@@ -3,12 +3,12 @@
         <span class="header-4">@lang('fortify::pages.user-settings.gdpr_title')</span>
         <span class="mt-4">@lang('fortify::pages.user-settings.gdpr_description')</span>
 
-        <div>
+        <div class="mt-4">
             <x-ark-flash />
         </div>
 
         <div class="flex justify-end mt-8">
-            <button type="submit" class="w-full button-secondary sm:w-auto" wire:click="export">@lang('fortify::actions.export_personal_data')</button>
+            <button wire:loading.attr="disabled" type="submit" class="w-full button-secondary sm:w-auto" wire:click="export">@lang('fortify::actions.export_personal_data')</button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/g4zqfq

- Disables the "export personal data button" while busy so you cannot click many times
- Adds the proper margin to the success message


## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
