### PR TITLE
fix: typo in class name that prevents the correct font from loading

### DIFF
--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -14,13 +14,13 @@ return [
 
     'sign-in' => [
         'forgot_password'  => 'Forgot password?',
-        'register_now'     => 'Not a member? <a href=":route" class="underline link semibold">Sign up</a>',
+        'register_now'     => 'Not a member? <a href=":route" class="underline link font-semibold">Sign up</a>',
     ],
 
     'register-form' => [
         'conditions'         => "Creating an account means you're okay with our <a href=':termsOfServiceRoute' class='link'>Terms of Service</a> and <a href=':privacyPolicyRoute' class='link'>Privacy Policy</a>.",
         'create_account'     => 'Create Account',
-        'already_member'     => 'Already have an account? <a href=":route" class="underline link semibold">Sign in</a>',
+        'already_member'     => 'Already have an account? <a href=":route" class="underline link font-semibold">Sign in</a>',
     ],
 
     'register' => [


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/f92qxg
Found a little bug that prevent to apply the correct font-family to a html tag.
Using `semibold` instead of `font-semibold` will load the default "serif" font-family.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
