### PR TITLE
feat: limit data exporting to once every 15 min

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "spatie/laravel-medialibrary": "^9.4",
         "konceiver/laravel-data-bags": "^1.1",
         "snipe/banbuilder": "^2.3",
-        "spatie/laravel-newsletter": "^4.9"
+        "spatie/laravel-newsletter": "^4.9",
+        "danharrin/livewire-rate-limiting": "^0.2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "566411355ae0cd1f66f9802eb4389e6d",
+    "content-hash": "9a92e6a4124c110d7194ba44593115c3",
     "packages": [
         {
             "name": "arkecosystem/ui",
@@ -190,6 +190,60 @@
                 }
             ],
             "time": "2021-01-20T22:51:39+00:00"
+        },
+        {
+            "name": "danharrin/livewire-rate-limiting",
+            "version": "v0.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/danharrin/livewire-rate-limiting.git",
+                "reference": "d97c0f8648d0dd1f03cdffbd69580cdf4e772a7b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/danharrin/livewire-rate-limiting/zipball/d97c0f8648d0dd1f03cdffbd69580cdf4e772a7b",
+                "reference": "d97c0f8648d0dd1f03cdffbd69580cdf4e772a7b",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "^8.0",
+                "php": "^7.2|^8.0"
+            },
+            "require-dev": {
+                "livewire/livewire": "^2.3",
+                "orchestra/testbench": "^6.2",
+                "phpunit/phpunit": "^9.4",
+                "symplify/monorepo-builder": "^9.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DanHarrin\\LivewireRateLimiting\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dan Harrin",
+                    "email": "dan@danharrin.com"
+                }
+            ],
+            "description": "Apply rate limiters to Laravel Livewire actions.",
+            "homepage": "https://github.com/danharrin/livewire-rate-limiting",
+            "support": {
+                "issues": "https://github.com/danharrin/livewire-rate-limiting/issues",
+                "source": "https://github.com/danharrin/livewire-rate-limiting"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/danharrin",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-02-01T20:46:01+00:00"
         },
         {
             "name": "dasprid/enum",

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Database\Factories;
 
 use ARKEcosystem\Fortify\Models\User;
+use ARKEcosystem\Fortify\Rules\PoliteUsername;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
@@ -56,5 +57,23 @@ final class UserFactory extends Factory
         return $this->state(fn () => [
             'username' => $this->faker->unique()->userName,
         ]);
+    }
+
+    /**
+     * Ensures the name doesnt have any profanity
+     *
+     * @return \Illuminate\Database\Eloquent\Factories\Factory
+     */
+    public function withoutProfanities()
+    {
+        $rule = resolve(PoliteUsername::class);
+
+        dd($rule);
+        // // do {
+        // //     $this->faker->unique()->userName
+        // // } while()
+        // return $this->state(fn () => [
+        //     'name' => $this->faker->unique()->userName,
+        // ]);
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -60,7 +60,7 @@ final class UserFactory extends Factory
     }
 
     /**
-     * Ensures the name doesnt have any profanity
+     * Ensures the name doesnt have any profanity.
      *
      * @return \Illuminate\Database\Eloquent\Factories\Factory
      */

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Database\Factories;
 
 use ARKEcosystem\Fortify\Models\User;
-use ARKEcosystem\Fortify\Rules\PoliteUsername;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
@@ -57,23 +56,5 @@ final class UserFactory extends Factory
         return $this->state(fn () => [
             'username' => $this->faker->unique()->userName,
         ]);
-    }
-
-    /**
-     * Ensures the name doesnt have any profanity.
-     *
-     * @return \Illuminate\Database\Eloquent\Factories\Factory
-     */
-    public function withoutProfanities()
-    {
-        $rule = resolve(PoliteUsername::class);
-
-        dd($rule);
-        // // do {
-        // //     $this->faker->unique()->userName
-        // // } while()
-        // return $this->state(fn () => [
-        //     'name' => $this->faker->unique()->userName,
-        // ]);
     }
 }

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 return [
     'invalid_2fa_authentication_code' => 'The provided two factor authentication code was invalid',
-    'export_limit_reached' => 'You can export your personal data once every 15 minutes.',
+    'export_limit_reached'            => 'You can export your personal data once every 15 minutes.',
     'invalid_2fa_authentication_code' => 'The provided two factor authentication code was invalid',
     'subscription'                    => [
         'duplicate' => "You're already subscribed.",

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 return [
     'invalid_2fa_authentication_code' => 'The provided two factor authentication code was invalid',
+    'export_limit_reached' => 'You can export your personal data once every 15 minutes.',
+    'invalid_2fa_authentication_code' => 'The provided two factor authentication code was invalid',
     'subscription'                    => [
         'duplicate' => "You're already subscribed.",
         'pending'   => 'You should shortly receive an email to confirm your subscription. You may need to check your spam folder if an email doesn’t arrive within a few minutes.',

--- a/resources/views/profile/export-user-data.blade.php
+++ b/resources/views/profile/export-user-data.blade.php
@@ -8,7 +8,11 @@
         </div>
 
         <div class="flex justify-end mt-8">
-            <button wire:loading.attr="disabled" type="submit" class="w-full button-secondary sm:w-auto" wire:click="export">@lang('fortify::actions.export_personal_data')</button>
+            <div @if($this->rateLimitReached()) data-tippy-content="@lang('fortify::messages.export_limit_reached')" @endif >
+                <button @if($this->rateLimitReached()) disabled @endif wire:loading.attr="disabled" type="submit" class="w-full button-secondary sm:w-auto" wire:click="export">
+                    @lang('fortify::actions.export_personal_data')
+                </button>
+            </div>
         </div>
     </div>
 </div>

--- a/src/Components/ExportUserData.php
+++ b/src/Components/ExportUserData.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace ARKEcosystem\Fortify\Components;
 
 use ARKEcosystem\Fortify\Components\Concerns\InteractsWithUser;
+use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
+use DanHarrin\LivewireRateLimiting\WithRateLimiting;
+use Illuminate\Support\Facades\RateLimiter;
 use Livewire\Component;
 use Spatie\PersonalDataExport\Jobs\CreatePersonalDataExportJob;
-use DanHarrin\LivewireRateLimiting\WithRateLimiting;
-use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
-use Illuminate\Support\Facades\RateLimiter;
 
 class ExportUserData extends Component
 {

--- a/src/Components/ExportUserData.php
+++ b/src/Components/ExportUserData.php
@@ -7,10 +7,14 @@ namespace ARKEcosystem\Fortify\Components;
 use ARKEcosystem\Fortify\Components\Concerns\InteractsWithUser;
 use Livewire\Component;
 use Spatie\PersonalDataExport\Jobs\CreatePersonalDataExportJob;
+use DanHarrin\LivewireRateLimiting\WithRateLimiting;
+use DanHarrin\LivewireRateLimiting\Exceptions\TooManyRequestsException;
+use Illuminate\Support\Facades\RateLimiter;
 
 class ExportUserData extends Component
 {
     use InteractsWithUser;
+    use WithRateLimiting;
 
     /**
      * Queue the export of the personal data for the authenticated user.
@@ -19,9 +23,20 @@ class ExportUserData extends Component
      */
     public function export(): void
     {
+        try {
+            $this->rateLimit(1, 15 * 60);
+        } catch (TooManyRequestsException $exception) {
+            return;
+        }
+
         dispatch(new CreatePersonalDataExportJob($this->user));
 
         flash()->success(trans('fortify::pages.user-settings.data_exported'));
+    }
+
+    public function rateLimitReached(): bool
+    {
+        return RateLimiter::tooManyAttempts($this->getRateLimitKey('export'), 1);
     }
 
     /**

--- a/tests/Components/ExportUserDataTest.php
+++ b/tests/Components/ExportUserDataTest.php
@@ -16,3 +16,18 @@ it('can export the user data', function () {
         ->call('export')
         ->assertSee(trans('fortify::pages.user-settings.data_exported'));
 });
+
+it('can only export the user data once every 15 min', function () {
+    $this->expectsJobs(CreatePersonalDataExportJob::class);
+
+    $component = Livewire::actingAs(createUserModel())
+        ->test(ExportUserData::class)
+        ->call('export')
+        ->assertSee(trans('fortify::pages.user-settings.data_exported'))
+        ->call('export')
+        ->assertDontSee(trans('fortify::pages.user-settings.data_exported'));
+
+    $this->travel(16)->minutes();
+
+    $component->call('export')->assertSee(trans('fortify::pages.user-settings.data_exported'));
+});


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/g98pc1

Now the user can ask for exporting his data once every 15 min.

![image](https://user-images.githubusercontent.com/17262776/113033875-bc720e00-914e-11eb-8530-55cc5949806a.png)

To test update this dependency on msq and try to export your personal data more than once in a 15 min range

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
