### PR TITLE
fix: accept comma on display name

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -9,7 +9,7 @@ return [
     'messages' => [
         'one_time_password'                                   => 'We were not able to enable two-factor authentication with this one-time password.',
         'polite_username'                                     => 'The given username contains words with profanities.',
-        'some_special_characters'                             => 'The :attribute can only contain letters, numbers and . & - _',
+        'some_special_characters'                             => 'The :attribute can only contain letters, numbers and . & - _ ,',
         'include_letters'                                     => 'The :attribute needs at least one letter',
         'start_with_letter_or_number'                         => 'The :attribute must start with a letter or a number',
 

--- a/src/Rules/DisplayNameCharacters.php
+++ b/src/Rules/DisplayNameCharacters.php
@@ -19,7 +19,7 @@ final class DisplayNameCharacters implements Rule
     public function passes($attribute, $value)
     {
         // Any (unicode letter or number and . - ' &)
-        $regex = '/^[[\p{L}\p{N}\p{Mn}\p{Pd} ._\'&]+$/u';
+        $regex = '/^[[\p{L}\p{N}\p{Mn}\p{Pd} ._\'&,]+$/u';
 
         return preg_match($regex, $value) > 0;
     }

--- a/tests/Rules/DisplayNameCharactersTest.php
+++ b/tests/Rules/DisplayNameCharactersTest.php
@@ -31,6 +31,7 @@ it('accepts name with unicode characters', function ($name) {
     'Père Noël',
     'Alfonso & sons',
     'Coca.Cola',
+    'Procter, Cremin and Crist',
 ]);
 
 it('accepts name with single quote', function () {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

The company names that come from the faker sometimes create names with a comma. That made me think that the comma can also be a common character of some projects.

real example: Quora, Inc.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
