### PR TITLE
refactor: clear validation after submitting the newsletter form

### DIFF
--- a/resources/views/newsletter/footer-subscription-form.blade.php
+++ b/resources/views/newsletter/footer-subscription-form.blade.php
@@ -12,7 +12,7 @@
         :hide-label="true"
     >
         <button type="submit" class="block px-2 text-theme-secondary-500 bg-white">
-            @svg('paper-plane', 'w-5 h-5')
+            <x-ark-icon name="paper-plane" />
         </button>
     </x-ark-input-with-icon>
 

--- a/src/Components/FooterEmailSubscriptionForm.php
+++ b/src/Components/FooterEmailSubscriptionForm.php
@@ -29,6 +29,8 @@ final class FooterEmailSubscriptionForm extends Component
         }
 
         $this->email = null;
+
+        $this->status = null;
     }
 
     /**

--- a/src/Components/FooterEmailSubscriptionForm.php
+++ b/src/Components/FooterEmailSubscriptionForm.php
@@ -29,8 +29,11 @@ final class FooterEmailSubscriptionForm extends Component
         }
 
         $this->email = null;
+    }
 
-        $this->status = null;
+    public function updatedEmail(): void
+    {
+        $this->validateOnly('email', ['email' => ['required', 'email']]);
     }
 
     /**

--- a/tests/Actions/SubscribeToNewsletterTest.php
+++ b/tests/Actions/SubscribeToNewsletterTest.php
@@ -35,5 +35,5 @@ it('should return false if not subscribed', function () {
     Config::set('newsletter.apiKey', 'test-test');
     Config::set('newsletter.lists.subscribers.id', 'list-id');
 
-    resolve(SubscribeToNewsletter::class)->execute('email@email.com', 'subscribers');
+    expect(resolve(SubscribeToNewsletter::class)->execute('email@email.com', 'subscribers'))->toBeFalse();
 });


### PR DESCRIPTION
## Summary

https://app.clickup.com/t/gb2uzt

@ItsANameToo ~~Was expecting to be able to clear that message by using `$this->resetValidation();` but then when using it I had an error message like "You are already subscribed" while I was testing it with unique random email addresses each time :hmhm:~~

Went for real time validation for the email field, only way for me to get it right and have a success message once submitted.

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged