### PR TITLE
fix: emit modalclosed after closing recovery code password modal

### DIFF
--- a/src/Components/TwoFactorAuthenticationForm.php
+++ b/src/Components/TwoFactorAuthenticationForm.php
@@ -125,6 +125,8 @@ class TwoFactorAuthenticationForm extends Component
         $this->confirmPasswordShown = false;
 
         $this->confirmedPassword = '';
+
+        $this->modalClosed();
     }
 
     public function hasConfirmedPassword(): bool


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/jb4fmx

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
