### PR TITLE
fix: reset password form visual indicators 

### DIFF
--- a/resources/views/auth/reset-password-form.blade.php
+++ b/resources/views/auth/reset-password-form.blade.php
@@ -13,7 +13,7 @@
         <div>
             <div class="flex flex-1">
                 <x-ark-input
-                    wire:model.defer="state.email"
+                    wire:model.defer="email"
                     no-model
                     type="email"
                     name="email"
@@ -30,7 +30,7 @@
 
         <x:ark-fortify::password-rules :password-rules="$passwordRules" rules-wrapper-class="grid gap-4 my-4 sm:grid-cols-2">
             <x-ark-input
-                model="state.password"
+                model="password"
                 type="password"
                 name="password"
                 :label="trans('fortify::forms.password')"
@@ -46,7 +46,7 @@
         <div>
             <div class="flex flex-1">
                 <x-ark-input
-                    model="state.password_confirmation"
+                    model="password_confirmation"
                     type="password"
                     name="password_confirmation"
                     :label="trans('fortify::forms.confirm_password')"

--- a/src/Components/ResetPasswordForm.php
+++ b/src/Components/ResetPasswordForm.php
@@ -16,18 +16,18 @@ class ResetPasswordForm extends Component
 
     public ?string $twoFactorSecret;
 
-    public array $state = [
-        'email'                 => '',
-        'password'              => '',
-        'password_confirmation' => '',
-    ];
+    public ?string $email = '';
+
+    public ?string $password = '';
+
+    public ?string $password_confirmation = '';
 
     public function mount(?string $token = null, ?string $email = null)
     {
         $this->token = $token;
 
         if ($email !== null) {
-            $this->state['email'] = $email;
+            $this->email = $email;
 
             $user = Models::user()::where('email', $email)->firstOrFail();
 

--- a/tests/Components/ResetPasswordFormTest.php
+++ b/tests/Components/ResetPasswordFormTest.php
@@ -14,11 +14,9 @@ it('can interact with the form', function () {
 
     Livewire::actingAs($user)
         ->test(ResetPasswordForm::class)
-        ->assertSet('state', [
-            'email'                 => null,
-            'password'              => '',
-            'password_confirmation' => '',
-        ])
+        ->assertSet('email', null)
+        ->assertSet('password', '')
+        ->assertSet('password_confirmation', '')
         ->assertViewIs('ark-fortify::auth.reset-password-form');
 });
 
@@ -32,11 +30,9 @@ it('gets the two factor code and the email', function () {
 
     Livewire::actingAs($user)
         ->test(ResetPasswordForm::class, ['email' => $user->email])
-        ->assertSet('state', [
-            'email'                 => $user->email,
-            'password'              => '',
-            'password_confirmation' => '',
-        ])
+        ->assertSet('email', $user->email)
+        ->assertSet('password', '')
+        ->assertSet('password_confirmation', '')
         ->assertSet('twoFactorSecret', 'secret')
         ->assertViewIs('ark-fortify::auth.reset-password-form');
 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/nte5dc

Removed the `state` array from the component since the trait related to the indicators expects the attributes.

Register form and account update password form works fine as they use attributes

To test use the "forget my password" form

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
