### PR TITLE
refactor: skip redirect to verification route if username is used instead of email

### DIFF
--- a/src/Responses/RegisterResponse.php
+++ b/src/Responses/RegisterResponse.php
@@ -7,7 +7,6 @@ namespace ARKEcosystem\Fortify\Responses;
 use ARKEcosystem\Fortify\Models;
 use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Support\Arr;
 use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 
 final class RegisterResponse implements RegisterResponseContract
@@ -38,7 +37,7 @@ final class RegisterResponse implements RegisterResponseContract
             }
         }
 
-        if (config('fortify.features') && in_array('email-verification', config('fortify.features'))) {
+        if (config('fortify.features') && in_array('email-verification', config('fortify.features'), true)) {
             return redirect()->route('verification.notice');
         }
     }

--- a/src/Responses/RegisterResponse.php
+++ b/src/Responses/RegisterResponse.php
@@ -7,6 +7,7 @@ namespace ARKEcosystem\Fortify\Responses;
 use ARKEcosystem\Fortify\Models;
 use Illuminate\Contracts\Routing\UrlGenerator;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Arr;
 use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 
 final class RegisterResponse implements RegisterResponseContract
@@ -37,10 +38,8 @@ final class RegisterResponse implements RegisterResponseContract
             }
         }
 
-        if (is_null(config('fortify.email'))) {
-            return redirect('/');
+        if (config('fortify.features') && in_array('email-verification', config('fortify.features'))) {
+            return redirect()->route('verification.notice');
         }
-
-        return redirect()->route('verification.notice');
     }
 }

--- a/src/Responses/RegisterResponse.php
+++ b/src/Responses/RegisterResponse.php
@@ -39,8 +39,8 @@ final class RegisterResponse implements RegisterResponseContract
 
         if (is_null(config('fortify.email'))) {
             return redirect('/');
-        } else {
-            return redirect()->route('verification.notice');
         }
+
+        return redirect()->route('verification.notice');
     }
 }

--- a/src/Responses/RegisterResponse.php
+++ b/src/Responses/RegisterResponse.php
@@ -37,6 +37,10 @@ final class RegisterResponse implements RegisterResponseContract
             }
         }
 
-        return redirect()->route('verification.notice');
+        if (is_null(config('fortify.email'))) {
+            return redirect('/');
+        } else {
+            return redirect()->route('verification.notice');
+        }
     }
 }

--- a/tests/Responses/RegisterResponseTest.php
+++ b/tests/Responses/RegisterResponseTest.php
@@ -103,3 +103,24 @@ it('redirects to the default url if no route for accept an invitation is set', f
     expect($response->status())->toBe(302);
     expect($response->content())->toContain(route('verification.notice'));
 });
+
+it('redirects to home if the username is used instead of the email', function () {
+    Config::set('fortify.email', null);
+    Config::set('fortify.username', 'username');
+    Config::set('fortify.models.user', \ARKEcosystem\Fortify\Models\User::class);
+
+    $request = Mockery::mock(\Illuminate\Http\Request::class);
+
+    $request
+        ->shouldReceive('get')
+        ->once()
+        ->shouldReceive('wantsJson')
+        ->once()
+        ->andReturnFalse();
+
+    $response = (new RegisterResponse())->toResponse($request);
+
+    expect($response)->toBeInstanceOf(RedirectResponse::class);
+    expect($response->status())->toBe(302);
+    expect($response->getTargetUrl())->toBe('http://localhost');
+});

--- a/tests/Responses/RegisterResponseTest.php
+++ b/tests/Responses/RegisterResponseTest.php
@@ -104,10 +104,18 @@ it('redirects to the default url if no route for accept an invitation is set', f
     expect($response->content())->toContain(route('verification.notice'));
 });
 
-it('redirects to home if the username is used instead of the email', function () {
+it('does not redirect to the verification.notice route at all if the email verification feature is disabled', function () {
     Config::set('fortify.email', null);
     Config::set('fortify.username', 'username');
     Config::set('fortify.models.user', \ARKEcosystem\Fortify\Models\User::class);
+
+    Config::set('fortify.features', [
+        "registration",
+        "reset-passwords",
+        "update-profile-information",
+        "update-passwords",
+        "two-factor-authentication",
+    ]);
 
     $request = Mockery::mock(\Illuminate\Http\Request::class);
 
@@ -120,7 +128,5 @@ it('redirects to home if the username is used instead of the email', function ()
 
     $response = (new RegisterResponse())->toResponse($request);
 
-    expect($response)->toBeInstanceOf(RedirectResponse::class);
-    expect($response->status())->toBe(302);
-    expect($response->getTargetUrl())->toBe('http://localhost');
+    expect($response)->toBeNull();
 });

--- a/tests/Responses/RegisterResponseTest.php
+++ b/tests/Responses/RegisterResponseTest.php
@@ -110,11 +110,11 @@ it('does not redirect to the verification.notice route at all if the email verif
     Config::set('fortify.models.user', \ARKEcosystem\Fortify\Models\User::class);
 
     Config::set('fortify.features', [
-        "registration",
-        "reset-passwords",
-        "update-profile-information",
-        "update-passwords",
-        "two-factor-authentication",
+        'registration',
+        'reset-passwords',
+        'update-profile-information',
+        'update-passwords',
+        'two-factor-authentication',
     ]);
 
     $request = Mockery::mock(\Illuminate\Http\Request::class);


### PR DESCRIPTION
## Summary

Related to https://github.com/ArkEcosystem/nodem/pull/102, last issue I was facing was the following exception : 
`Symfony\Component\Routing\Exception\RouteNotFoundException Route [verification.notice] not defined.`

So, removing that redirect if we don't use the email at all, and redirect on the homepage instead, which fix my issue on Nodem. 

## Checklist

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged