### PR TITLE
refactor: place cta button always on the right

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -81,11 +81,13 @@
                 @php($hasForgotPassword = Route::has('password.request'))
 
                 <div class="flex flex-col-reverse items-center space-y-4 sm:space-y-0 sm:flex-row {{ $hasForgotPassword ? 'justify-between' : 'justify-end' }}">
+                    <div>
                     @if($hasForgotPassword)
                         <div class="flex-1 mt-8 sm:mt-0">
                             <a href="{{ route('password.request') }}" class="link font-semibold">@lang('fortify::auth.sign-in.forgot_password')</a>
                         </div>
                     @endif
+                    </div>
 
                     <button type="submit" class="w-full button-secondary sm:w-auto">
                         @lang('fortify::actions.sign_in')


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/p78qpf

This PR changes the "Sign in" button on "login" form to stick always on the right position, even when the "forgot password" login is hidden.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
