### PR TITLE
feat: 2fa disable confirmation modal

### DIFF
--- a/resources/lang/en/forms.php
+++ b/resources/lang/en/forms.php
@@ -66,6 +66,6 @@ return [
         'disable-2fa' => [
             'title'        => 'Disable 2FA',
             'description'  => 'Input your password to disable the two-factor authentication method.',
-        ]
+        ],
     ],
 ];

--- a/resources/lang/en/forms.php
+++ b/resources/lang/en/forms.php
@@ -59,7 +59,13 @@ return [
     ],
 
     'confirm-password' => [
-        'title'        => '2FA Recovery Codes',
-        'description'  => 'Input your password to show your emergency two-factor recovery codes.',
+        'recovery-codes' => [
+            'title'        => '2FA Recovery Codes',
+            'description'  => 'Input your password to show your emergency two-factor recovery codes.',
+        ],
+        'disable-2fa' => [
+            'title'        => 'Disable 2FA',
+            'description'  => 'Input your password to disable the two-factor authentication method.',
+        ]
     ],
 ];

--- a/resources/views/components/confirm-password-modal.blade.php
+++ b/resources/views/components/confirm-password-modal.blade.php
@@ -1,0 +1,42 @@
+@if($this->confirmPasswordShown)
+    <x-ark-modal title-class="header-2" width-class="max-w-2xl" wire-close="cancelConfirmPassword">
+        <x-slot name="title">
+            {{ $this->confirmPasswordTitle }}
+        </x-slot>
+
+        <x-slot name="description">
+            <div class="flex flex-col mt-4">
+                <div class="flex justify-center w-full mt-8">
+                    <img src="{{ asset('/images/auth/confirm-password.svg') }}" class="w-auto h-auto" alt="">
+                </div>
+                <div class="mt-8">
+                    {{ $this->confirmPasswordDescription }}
+                </div>
+            </div>
+            <form class="mt-8">
+                <div class="space-y-2">
+                    <input type="hidden" autocomplete="email" />
+
+                    <x-ark-password-toggle
+                        name="password"
+                        model="confirmedPassword"
+                        :label="trans('fortify::forms.password')"
+                        autocomplete="current-password"
+                    />
+                </div>
+            </form>
+        </x-slot>
+
+        <x-slot name="buttons">
+            <div class="flex flex-col-reverse justify-end w-full space-y-4 space-y-reverse sm:flex-row sm:space-y-0 sm:space-x-3">
+                <button type="button" dusk="confirm-password-form-cancel" class="button-secondary" wire:click="cancelConfirmPassword">
+                    @lang('fortify::actions.cancel')
+                </button>
+
+                <button type="submit" dusk="confirm-password-form-submit" class="inline-flex items-center justify-center button-primary" wire:click="submitConfirmPassword" {{ ! $this->hasConfirmedPassword() ? 'disabled' : ''}}>
+                    <span>@lang('fortify::actions.confirm')</span>
+                </button>
+            </div>
+        </x-slot>
+    </x-ark-modal>
+@endif

--- a/resources/views/profile/two-factor-authentication-form.blade.php
+++ b/resources/views/profile/two-factor-authentication-form.blade.php
@@ -140,14 +140,14 @@
             </div>
 
             <div class="flex flex-col w-full mt-8 space-y-3 sm:flex-row sm:justify-end sm:space-y-0 sm:space-x-3">
-                <button type="button" class="w-full button-secondary sm:w-auto" wire:click="showConfirmPassword">
+                <button type="button" class="w-full button-secondary sm:w-auto" wire:click="showRecoveryCodesConfirmationModal">
                     @lang('fortify::actions.recovery_codes')
                 </button>
 
                 <button
                     type="submit"
                     class="w-full button-primary sm:w-auto"
-                    wire:click="disableTwoFactorAuthentication"
+                    wire:click="showDisable2FAModal"
                     dusk="disable-two-factor-authentication"
                 >
                     @lang('fortify::actions.disable')
@@ -215,45 +215,5 @@
         @endif
     </div>
 
-    @if($this->confirmPasswordShown)
-        <x-ark-modal title-class="header-2" width-class="max-w-2xl" wire-close="closeConfirmPassword">
-            <x-slot name="title">
-                @lang('fortify::forms.confirm-password.title')
-            </x-slot>
-
-            <x-slot name="description">
-                <div class="flex flex-col mt-4">
-                    <div class="flex justify-center w-full mt-8">
-                        <img src="{{ asset('/images/auth/confirm-password.svg') }}" class="w-auto h-auto" alt="">
-                    </div>
-                    <div class="mt-8">
-                        @lang('fortify::forms.confirm-password.description')
-                    </div>
-                </div>
-                <form class="mt-8">
-                    <div class="space-y-2">
-                        <input type="hidden" autocomplete="email" />
-                        <x-ark-password-toggle
-                            name="password"
-                            model="confirmedPassword"
-                            :label="trans('fortify::forms.password')"
-                            autocomplete="current-password"
-                        />
-                    </div>
-                </form>
-            </x-slot>
-
-            <x-slot name="buttons">
-                <div class="flex flex-col-reverse justify-end w-full space-y-4 space-y-reverse sm:flex-row sm:space-y-0 sm:space-x-3">
-                    <button type="button" dusk="confirm-password-form-cancel" class="button-secondary" wire:click="closeConfirmPassword">
-                        @lang('fortify::actions.cancel')
-                    </button>
-
-                    <button type="submit" dusk="confirm-password-form-submit" class="inline-flex items-center justify-center button-primary" wire:click="showRecoveryCodesAfterPasswordConfirmation" {{ ! $this->hasConfirmedPassword() ? 'disabled' : ''}}>
-                        <span>@lang('fortify::actions.confirm')</span>
-                    </button>
-                </div>
-            </x-slot>
-        </x-ark-modal>
-    @endif
+    <x-ark-fortify::confirm-password-modal />
 </div>

--- a/src/Components/Concerns/ConfirmsPassword.php
+++ b/src/Components/Concerns/ConfirmsPassword.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ARKEcosystem\Fortify\Components\Concerns;
+
+use ARKEcosystem\UserInterface\Http\Livewire\Concerns\HasModal;
+use Illuminate\Support\Facades\Hash;
+
+trait ConfirmsPassword
+{
+    use InteractsWithUser;
+    use HasModal;
+
+    public bool $confirmPasswordShown = false;
+
+    public string $confirmedPassword = '';
+
+    public string $confirmPasswordTitle = '';
+
+    public string $confirmPasswordDescription = '';
+
+    public ?string $confirmPasswordOnClose = null;
+
+    public ?string $confirmPasswordOnConfirm = null;
+
+    public function showConfirmPassword(
+        string $title = '',
+        string $description = '',
+        ?string $onConfirm = null,
+        ?string $onClose = null,
+    ): void
+    {
+        $this->confirmPasswordTitle = $title;
+
+        $this->confirmPasswordDescription = $description;
+
+        $this->confirmPasswordOnConfirm = $onConfirm;
+
+        $this->confirmPasswordOnClose = $onClose;
+
+        $this->confirmPasswordShown = true;
+    }
+
+
+    public function resetConfirmModal(): void
+    {
+        $this->confirmPasswordShown = false;
+
+        $this->confirmedPassword = '';
+
+        $this->confirmPasswordTitle = '';
+
+        $this->confirmPasswordDescription = '';
+
+        $this->confirmPasswordOnClose = null;
+
+        $this->confirmPasswordOnConfirm = null;
+
+        $this->modalClosed();
+    }
+
+
+    public function cancelConfirmPassword(): void
+    {
+        if ($this->confirmPasswordOnClose && method_exists($this, $this->confirmPasswordOnClose)) {
+            $this->{$this->confirmPasswordOnClose}();
+        }
+
+        $this->resetConfirmModal();
+    }
+
+    public function submitConfirmPassword(): void
+    {
+        if ($this->confirmPasswordOnConfirm && method_exists($this, $this->confirmPasswordOnConfirm)) {
+            $this->{$this->confirmPasswordOnConfirm}();
+        }
+
+        $this->resetConfirmModal();
+    }
+
+    public function hasConfirmedPassword(): bool
+    {
+        return Hash::check($this->confirmedPassword, $this->user->password);
+    }
+}

--- a/src/Components/Concerns/ConfirmsPassword.php
+++ b/src/Components/Concerns/ConfirmsPassword.php
@@ -22,7 +22,7 @@ trait ConfirmsPassword
 
     public string $confirmPasswordDescription = '';
 
-    public ?string $confirmPasswordOnConfirm = null;
+    private ?string $confirmPasswordOnConfirm = null;
 
     private function showConfirmPassword(
         string $title = '',

--- a/src/Components/Concerns/ConfirmsPassword.php
+++ b/src/Components/Concerns/ConfirmsPassword.php
@@ -20,23 +20,18 @@ trait ConfirmsPassword
 
     public string $confirmPasswordDescription = '';
 
-    public ?string $confirmPasswordOnClose = null;
-
     public ?string $confirmPasswordOnConfirm = null;
 
     public function showConfirmPassword(
         string $title = '',
         string $description = '',
         ?string $onConfirm = null,
-        ?string $onClose = null,
     ): void {
         $this->confirmPasswordTitle = $title;
 
         $this->confirmPasswordDescription = $description;
 
         $this->confirmPasswordOnConfirm = $onConfirm;
-
-        $this->confirmPasswordOnClose = $onClose;
 
         $this->confirmPasswordShown = true;
     }
@@ -51,8 +46,6 @@ trait ConfirmsPassword
 
         $this->confirmPasswordDescription = '';
 
-        $this->confirmPasswordOnClose = null;
-
         $this->confirmPasswordOnConfirm = null;
 
         $this->modalClosed();
@@ -60,10 +53,6 @@ trait ConfirmsPassword
 
     public function cancelConfirmPassword(): void
     {
-        if ($this->confirmPasswordOnClose && method_exists($this, $this->confirmPasswordOnClose)) {
-            $this->{$this->confirmPasswordOnClose}();
-        }
-
         $this->resetConfirmModal();
     }
 

--- a/src/Components/Concerns/ConfirmsPassword.php
+++ b/src/Components/Concerns/ConfirmsPassword.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ARKEcosystem\Fortify\Components\Concerns;
 
 use ARKEcosystem\UserInterface\Http\Livewire\Concerns\HasModal;
-use Error;
 use Exception;
 use Illuminate\Support\Facades\Hash;
 

--- a/src/Components/Concerns/ConfirmsPassword.php
+++ b/src/Components/Concerns/ConfirmsPassword.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace ARKEcosystem\Fortify\Components\Concerns;
 
 use ARKEcosystem\UserInterface\Http\Livewire\Concerns\HasModal;
+use Error;
+use Exception;
 use Illuminate\Support\Facades\Hash;
 
 trait ConfirmsPassword
@@ -58,6 +60,11 @@ trait ConfirmsPassword
 
     public function submitConfirmPassword(): void
     {
+        if (! $this->hasConfirmedPassword()) {
+            // the only way to get here is if the user faked the ajax request
+            throw new Exception();
+        }
+
         if ($this->confirmPasswordOnConfirm && method_exists($this, $this->confirmPasswordOnConfirm)) {
             $this->{$this->confirmPasswordOnConfirm}();
         }

--- a/src/Components/Concerns/ConfirmsPassword.php
+++ b/src/Components/Concerns/ConfirmsPassword.php
@@ -24,7 +24,7 @@ trait ConfirmsPassword
 
     public ?string $confirmPasswordOnConfirm = null;
 
-    public function showConfirmPassword(
+    private function showConfirmPassword(
         string $title = '',
         string $description = '',
         ?string $onConfirm = null,
@@ -38,7 +38,7 @@ trait ConfirmsPassword
         $this->confirmPasswordShown = true;
     }
 
-    public function resetConfirmModal(): void
+    private function resetConfirmModal(): void
     {
         $this->confirmPasswordShown = false;
 

--- a/src/Components/Concerns/ConfirmsPassword.php
+++ b/src/Components/Concerns/ConfirmsPassword.php
@@ -29,8 +29,7 @@ trait ConfirmsPassword
         string $description = '',
         ?string $onConfirm = null,
         ?string $onClose = null,
-    ): void
-    {
+    ): void {
         $this->confirmPasswordTitle = $title;
 
         $this->confirmPasswordDescription = $description;
@@ -41,7 +40,6 @@ trait ConfirmsPassword
 
         $this->confirmPasswordShown = true;
     }
-
 
     public function resetConfirmModal(): void
     {
@@ -59,7 +57,6 @@ trait ConfirmsPassword
 
         $this->modalClosed();
     }
-
 
     public function cancelConfirmPassword(): void
     {

--- a/src/Components/Concerns/ConfirmsPassword.php
+++ b/src/Components/Concerns/ConfirmsPassword.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ARKEcosystem\Fortify\Components\Concerns;
 
 use ARKEcosystem\UserInterface\Http\Livewire\Concerns\HasModal;
-use Error;
 use Exception;
 use Illuminate\Support\Facades\Hash;
 
@@ -22,7 +21,7 @@ trait ConfirmsPassword
 
     public string $confirmPasswordDescription = '';
 
-    private ?string $confirmPasswordOnConfirm = null;
+    public ?string $confirmPasswordOnConfirm = null;
 
     private function showConfirmPassword(
         string $title = '',
@@ -38,7 +37,7 @@ trait ConfirmsPassword
         $this->confirmPasswordShown = true;
     }
 
-    private function resetConfirmModal(): void
+    public function resetConfirmModal(): void
     {
         $this->confirmPasswordShown = false;
 

--- a/src/Components/TwoFactorAuthenticationForm.php
+++ b/src/Components/TwoFactorAuthenticationForm.php
@@ -61,7 +61,7 @@ class TwoFactorAuthenticationForm extends Component
         $this->showRecoveryCodes();
     }
 
-    public function showRecoveryCodes(): void
+    private function showRecoveryCodes(): void
     {
         $this->openModal();
     }
@@ -73,7 +73,7 @@ class TwoFactorAuthenticationForm extends Component
         $this->showRecoveryCodes();
     }
 
-    public function disableTwoFactorAuthentication(): void
+    private function disableTwoFactorAuthentication(): void
     {
         app(DisableTwoFactorAuthentication::class)(Auth::user());
 

--- a/tests/Components/TwoFactorAuthenticationFormTest.php
+++ b/tests/Components/TwoFactorAuthenticationFormTest.php
@@ -40,7 +40,14 @@ it('can interact with the form', function () {
         ->call('submitConfirmPassword')
         ->assertSee('If you lose your two-factor authentication device')
         ->call('hideRecoveryCodes')
-        // Disable 2FA
+        // Show disable 2FA confirmation modal
+        ->call('showDisable2FAModal')
+        ->assertSee('Input your password to disable the two-factor authentication method.')
+        // Cancel disable 2FA
+        ->call('cancelConfirmPassword')
+        ->assertDontSee('Input your password to disable the two-factor authentication method.')
+        ->assertDontSee('You have not enabled two factor authentication')
+        // Try again
         ->call('showDisable2FAModal')
         ->assertSee('Input your password to disable the two-factor authentication method.')
         ->set('confirmedPassword', 'password')

--- a/tests/Components/TwoFactorAuthenticationFormTest.php
+++ b/tests/Components/TwoFactorAuthenticationFormTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use ARKEcosystem\Fortify\Components\TwoFactorAuthenticationForm;
 use Livewire\Livewire;
 use PragmaRX\Google2FALaravel\Google2FA;
+
 use function Tests\createUserModel;
 
 it('can interact with the form', function () {
@@ -53,4 +54,37 @@ it('can interact with the form', function () {
         ->set('confirmedPassword', 'password')
         ->call('submitConfirmPassword')
         ->assertSee('You have not enabled two factor authentication');
+});
+
+
+it('cannot disable 2FA if password is not confirmed', function () {
+    // Expecting exception
+    $this->expectException(Exception::class);
+
+    $user = createUserModel();
+
+    $g2FA = $this->mock(Google2FA::class);
+    $g2FA->shouldReceive('verifyKey')
+        ->andReturnTrue();
+    app()->instance('pragmarx.google2fa', $g2FA);
+
+    $two_factor_secret = 'QHBRXHLWOT3B2T3L';
+    Livewire::actingAs($user)
+        ->test(TwoFactorAuthenticationForm::class)
+        ->assertSee('You have not enabled two factor authentication.')
+        ->set('state.two_factor_secret', $two_factor_secret)
+        ->assertSet('enabled', false)
+        ->assertSee($two_factor_secret)
+        ->set('state.otp', '843733')
+        ->call('enableTwoFactorAuthentication')
+        ->assertSee('Two-Factor Authentication Recovery Codes')
+        ->assertSee('If you lose your two-factor authentication device')
+        ->call('hideRecoveryCodes')
+        ->assertSee('You have enabled two factor authentication')
+        ->call('showDisable2FAModal')
+        ->assertSee('Input your password to disable the two-factor authentication method.')
+        // Im not adding the `->set('confirmedPassword', 'password')` method here
+        // so calling `submitConfirmPassword` should fail
+        ->call('submitConfirmPassword')
+        ->assertDontSee('You have not enabled two factor authentication');
 });

--- a/tests/Components/TwoFactorAuthenticationFormTest.php
+++ b/tests/Components/TwoFactorAuthenticationFormTest.php
@@ -56,7 +56,6 @@ it('can interact with the form', function () {
         ->assertSee('You have not enabled two factor authentication');
 });
 
-
 it('cannot disable 2FA if password is not confirmed', function () {
     // Expecting exception
     $this->expectException(Exception::class);

--- a/tests/Components/TwoFactorAuthenticationFormTest.php
+++ b/tests/Components/TwoFactorAuthenticationFormTest.php
@@ -33,12 +33,17 @@ it('can interact with the form', function () {
         ->assertSee('Two-Factor Authentication Recovery Codes')
         ->call('hideRecoveryCodes')
         ->assertSee('You have enabled two factor authentication')
-        ->call('showConfirmPassword')
+        // Show recovery codes
+        ->call('showRecoveryCodesConfirmationModal')
         ->assertSee('Input your password to show your emergency two-factor recovery codes.')
         ->set('confirmedPassword', 'password')
-        ->call('showRecoveryCodesAfterPasswordConfirmation')
+        ->call('submitConfirmPassword')
         ->assertSee('If you lose your two-factor authentication device')
         ->call('hideRecoveryCodes')
-        ->call('disableTwoFactorAuthentication')
+        // Disable 2FA
+        ->call('showDisable2FAModal')
+        ->assertSee('Input your password to disable the two-factor authentication method.')
+        ->set('confirmedPassword', 'password')
+        ->call('submitConfirmPassword')
         ->assertSee('You have not enabled two factor authentication');
 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/p5g5z3

### To test
1. Add a 2fa method to your account
2. Since this PR refactored the modal for showing recovery codes so we can reuse it, test that action first
3. Try to disable the 2fa, you should see the modal on the screenshot

![image](https://user-images.githubusercontent.com/17262776/125976990-11a5e840-8d95-484d-9772-a96fa4aae14a.png)

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
