### PR TITLE
refactor: prevent display error for Username label within login form

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -38,13 +38,11 @@
                     @php
                         $username = \Laravel\Fortify\Fortify::username();
                         $usernameAlt = Config::get('fortify.username_alt');
+                        $email = Config::get('fortify.email');
                         $type = 'text';
 
-                        if ($username === $usernameAlt && ! Config::get('fortify.email') === null) {
-                            $label = trans('fortify::forms.'.$username);
-                        }
-                        elseif ($usernameAlt) {
-                            $label = trans('fortify::forms.'.$username).' or '.trans('fortify::forms.'.$usernameAlt);
+                        if ($usernameAlt === $username && ! is_null($email)) {
+                            $label = trans('fortify::forms.'.$username).' or '.trans('fortify::forms.'.$email);
                         } else {
                             $label = trans('fortify::forms.'.$username);
                             if ($username === 'email') {

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -40,7 +40,10 @@
                         $usernameAlt = Config::get('fortify.username_alt');
                         $type = 'text';
 
-                        if ($usernameAlt) {
+                        if ($username === $usernameAlt && ! Config::get('fortify.email') === null) {
+                            $label = trans('fortify::forms.'.$username);
+                        }
+                        elseif ($usernameAlt) {
                             $label = trans('fortify::forms.'.$username).' or '.trans('fortify::forms.'.$usernameAlt);
                         } else {
                             $label = trans('fortify::forms.'.$username);


### PR DESCRIPTION
## Summary

Issue happening on Nodem where we use Username and not Email at all : 

![](https://user-images.githubusercontent.com/8069294/126147761-f41067bc-6bf0-4a4c-a658-1affe2ea614d.png)

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged