### PR TITLE
fix: show password indicators on reset password form

### DIFF
--- a/resources/views/auth/reset-password-form.blade.php
+++ b/resources/views/auth/reset-password-form.blade.php
@@ -28,7 +28,12 @@
             </div>
         </div>
 
-        <x:ark-fortify::password-rules :password-rules="$passwordRules" rules-wrapper-class="grid gap-4 my-4 sm:grid-cols-2">
+        <x:ark-fortify::password-rules
+            :password-rules="$this->passwordRules"
+            rules-wrapper-class="grid gap-4 my-4 sm:grid-cols-2"
+            is-typing="isTyping"
+            @typing="isTyping=true"
+        >
             <x-ark-password-toggle
                 model="password"
                 name="password"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/nte5dc

Add `isTyping` property in reset password form to show the indicators

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
