### PR TITLE
refactor: make `email` in qr-code information swappable

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ private function registerDataBags(): void
 
 ### Two Factor Authentication
 
+> Under the hood we use [**Pragmarx Google2fa-laravel**](https://github.com/antonioribeiro/google2fa-laravel#readme) package.  
+> 
+> For custom configuration like [generating QR-Code using SVG render](https://github.com/antonioribeiro/google2fa-laravel#qrcode-backend) instead of a default Imagemagick, 
+> you can [publish the default configuration](https://github.com/antonioribeiro/google2fa-laravel#publish-the-config-file) and adjust it as per your needs.
+
 1. Add file download JS to Mix file
 
 ```js
@@ -131,14 +136,6 @@ private function registerDataBags(): void
 ```bash
 yarn prod
 ```
-
-> Be sure to have `Imagick` extension installed.
-
-To check if you have the extension installed on your system, run this command on your terminal: 
-```bash
-$ php -m | grep -i magic
-```
-if the extension is already installed you'll see the name `imagick` as a result.
 
 ### Required images
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,14 @@ private function registerDataBags(): void
 yarn prod
 ```
 
+> Be sure to have `Imagick` extension installed.
+
+To check if you have the extension installed on your system, run this command on your terminal: 
+```bash
+$ php -m | grep -i magic
+```
+if the extension is already installed you'll see the name `imagick` as a result.
+
 ### Required images
 
 #### Password Confirmation modal

--- a/src/Components/TwoFactorAuthenticationForm.php
+++ b/src/Components/TwoFactorAuthenticationForm.php
@@ -122,7 +122,7 @@ class TwoFactorAuthenticationForm extends Component
     {
         return app(TwoFactorAuthenticationProvider::class)->qrCodeUrl(
             config('app.name'),
-            $this->user->email,
+            (string) data_get($this->user, config('fortify.username'), 'email'),
             $this->state['two_factor_secret']
         );
     }

--- a/tests/Components/TwoFactorAuthenticationFormTest.php
+++ b/tests/Components/TwoFactorAuthenticationFormTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use ARKEcosystem\Fortify\Components\TwoFactorAuthenticationForm;
+use Illuminate\Support\Facades\Config;
 use Livewire\Livewire;
 use PragmaRX\Google2FALaravel\Google2FA;
 use function Tests\createUserModel;
@@ -96,4 +97,26 @@ it('should not disable if wrong password', function () {
         ->set('confirmedPassword', 'wrong password')
         ->call('disableTwoFactorAuthentication')
         ->assertDontSee('You have not enabled two factor authentication');
+});
+
+it('shows email after scanning qr-code on mobile device', function (): void {
+    $user = createUserModel();
+
+    $instance = Livewire::actingAs($user)
+        ->test(TwoFactorAuthenticationForm::class)
+        ->instance();
+
+    expect($instance->twoFactorQrCodeUrl)->toContain(urlencode($user->email));
+});
+
+it('shows username after scanning qr-code on mobile device', function (): void {
+    Config::set('fortify.username', 'username');
+
+    $user = createUserModel();
+
+    $instance = Livewire::actingAs($user)
+        ->test(TwoFactorAuthenticationForm::class)
+        ->instance();
+
+    expect($instance->twoFactorQrCodeUrl)->toContain(urlencode($user->username));
 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Related to https://app.clickup.com/t/pkdm90

This PR makes qr-code generation handle the correct user information by swapping email with username and vice-versa.
The result properly shows user information on mobile device after scanning the qr-code.
![image](https://user-images.githubusercontent.com/2118799/126966523-a9bb19c4-d379-4c16-a443-8d4efdc94bc9.png)


## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [x] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
