### PR TITLE
fix: use regular external link component for 2auth links

### DIFF
--- a/resources/views/profile/two-factor-authentication-form.blade.php
+++ b/resources/views/profile/two-factor-authentication-form.blade.php
@@ -1,16 +1,18 @@
 @php
     use \Illuminate\View\ComponentAttributeBag;
 
-    $twoAuthLink1 = view('ark::external-link-confirm', [
+    $twoAuthLink1 = view('ark::external-link', [
         'attributes' => new ComponentAttributeBag([]),
         'text' => 'Authy',
         'url' => 'https://authy.com',
+        'inline' => true,
     ])->render();
 
-    $twoAuthLink2 = view('ark::external-link-confirm', [
+    $twoAuthLink2 = view('ark::external-link', [
         'attributes' => new ComponentAttributeBag([]),
         'text' => 'Google Authenticator',
         'url' => 'https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2',
+        'inline' => true,
     ])->render();
 @endphp
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/r4yyph

The links are still using the old `external-link-confirm` component that is no longer used like that anymore.

This PR replaced that component for the regular `external-link` component that is the correct one to use.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
