### PR TITLE
fix: password toggle on disable 2FA modal

### DIFF
--- a/resources/views/components/modals/password-confirmation.blade.php
+++ b/resources/views/components/modals/password-confirmation.blade.php
@@ -43,9 +43,7 @@
                 <x-ark-password-toggle
                     name="confirmedPassword"
                     :label="trans('fortify::forms.password')"
-                    autocomplete="current-password"
                     :errors="$errors"
-                    masked
                 />
             </div>
         </form>

--- a/resources/views/components/modals/password-confirmation.blade.php
+++ b/resources/views/components/modals/password-confirmation.blade.php
@@ -30,6 +30,7 @@
         </div>
 
         <form
+            id="password-confirmation"
             class="mt-8"
             @keydown.enter="$wire.{{ $actionMethod }}()"
             x-on:submit.prevent
@@ -62,6 +63,7 @@
 
             <button
                 type="submit"
+                form="password-confirmation"
                 dusk="confirm-password-form-submit"
                 class="inline-flex items-center justify-center button-primary"
                 wire:click="{{ $actionMethod }}"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/pqenbt
Waiting on https://github.com/ArkEcosystem/laravel-ui/pull/618

This PR fixes "password toggle" on disable 2FA modal

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
