### PR TITLE
refactor: use xl size for password confirmation modal

### DIFF
--- a/resources/views/components/modals/password-confirmation.blade.php
+++ b/resources/views/components/modals/password-confirmation.blade.php
@@ -8,7 +8,7 @@
 
 <x-ark-modal
     title-class="header-2"
-    width-class="max-w-2xl"
+    width-class="max-w-xl"
     :wire-close="$closeMethod"
 >
     <x-slot name="title">


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/z9nkrm
Changes the max-width of the 2fa password confirmation modal to match the size used when confirming an email update. (576px)

To test: merge this on msq, add a 2fa code and try to disable it or to show the recovery codes

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
